### PR TITLE
Replace clipping with Bounded parameterization

### DIFF
--- a/dwave/plugins/torch/parametrizations.py
+++ b/dwave/plugins/torch/parametrizations.py
@@ -1,0 +1,27 @@
+# Copyright 2025 D-Wave
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+
+class Bounded(torch.nn.Module):
+    def __init__(self, lower_bound, upper_bound, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if lower_bound > upper_bound:
+            raise ValueError("Lower bound must be less than or equal to upper bound.")
+        self.lower_bound = lower_bound
+        self.upper_bound = upper_bound
+
+    def forward(self, x: torch.Tensor):
+        return torch.clip(x, self.lower_bound, self.upper_bound)

--- a/tests/test_boltzmann_machine.py
+++ b/tests/test_boltzmann_machine.py
@@ -50,11 +50,6 @@ class TestGraphRestrictedBoltzmannMachine(unittest.TestCase):
         self.sample_2 = torch.vstack([self.ones, self.ones, self.ones, self.mpones])
         return super().setUp()
 
-    def test_register_forward_pre_hook(self):
-        self.bm.h_range = torch.tensor([-0.1, 0.1])
-        self.bm.j_range = torch.tensor([-0.1, 0.2])
-        self.assertEqual(-0.1 * 3 + 4 * 0.2, self.bm(self.mones).item())
-
     def test_forward(self):
         with self.subTest("Manually-computed energies"):
             self.assertEqual(18, self.bm(self.ones).item())
@@ -146,8 +141,9 @@ class TestGraphRestrictedBoltzmannMachine(unittest.TestCase):
                 h_range=hr,
                 j_range=jr,
             )
-            bm.h.data = torch.tensor([-123, 0, 0, 567.0])
-            bm.J.data = torch.tensor([5555, -333.3, 0, 0])
+
+            bm.parametrizations["h"].original.data = torch.tensor([-123, 0, 0, 567.0])
+            bm.parametrizations["J"].original.data = torch.tensor([5555, -333.3, 0, 0])
             h, J = bm.ising
 
             self.assertEqual(min(h), hr[0])


### PR DESCRIPTION
Replace clipping with [pytorch's parameterizations](https://docs.pytorch.org/tutorials/intermediate/parametrizations.html).
In the current implementation, clipping is applied in numerous places and makes it more prone to bugs.
PyTorch's parameterization pattern is designed for this exact use case.