### PR TITLE
Enable custom weight initialization and setting

### DIFF
--- a/dwave/plugins/torch/boltzmann_machine.py
+++ b/dwave/plugins/torch/boltzmann_machine.py
@@ -105,7 +105,7 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
         #     defined above
         self._setup_hidden()
 
-    def set_linear(self, linear: dict[tuple[Hashable], float]):
+    def set_linear(self, linear: dict[tuple[Hashable], float]) -> None:
         """Set linear biases of the model.
 
         Args:
@@ -116,7 +116,7 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
             idx = self.node_to_idx[node]
             self._linear.data[idx] = bias
 
-    def set_quadratic(self, quadratic: dict[tuple[Hashable, Hashable], float]):
+    def set_quadratic(self, quadratic: dict[tuple[Hashable, Hashable], float]) -> None:
         """Set quadratic biases of the model.
 
         Args:

--- a/dwave/plugins/torch/boltzmann_machine.py
+++ b/dwave/plugins/torch/boltzmann_machine.py
@@ -110,7 +110,8 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
 
         Args:
             linear (dict[tuple[Hashable], float]): A dictionary mapping from nodes of the model to
-                its corresponding linear bias.
+                its corresponding linear bias. Not all linear biases need to be set; nodes without a
+                mapping will default to its initialized values.
         """
         for node, bias in linear.items():
             idx = self.node_to_idx[node]
@@ -121,7 +122,8 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
 
         Args:
             quadratic (dict[tuple[Hashable, Hashable], float]): A dictionary mapping from edges of
-                the model to its corresponding quadratic bias.
+                the model to its corresponding quadratic bias. Not all quadratic biases need to be
+                set; edges without a mapping will default to its initialized values.
         """
         for (u, v), bias in quadratic.items():
             idx = self._edge_to_idx.get((u, v), self._edge_to_idx.get((v, u)))

--- a/dwave/plugins/torch/boltzmann_machine.py
+++ b/dwave/plugins/torch/boltzmann_machine.py
@@ -54,6 +54,10 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
         edges (Iterable[tuple[Hashable, Hashable]]): List of edges.
         hidden_nodes (Iterable[Hashable], optional): List of hidden nodes. Each hidden node should
             also be listed in the input ``nodes``.
+        linear (dict[tuple[Hashable], float], optional): A dictionary mapping from nodes of the
+            model to its corresponding linear bias.
+        quadratic (dict[tuple[Hashable, Hashable], float]): A dictionary mapping from edges of the
+            model to its corresponding quadratic bias.
     """
 
     def __init__(
@@ -116,8 +120,8 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
         """Set quadratic biases of the model.
 
         Args:
-            linear (dict[tuple[Hashable], float]): A dictionary mapping from edges of the model to
-                its corresponding linear bias.
+            quadratic (dict[tuple[Hashable, Hashable], float]): A dictionary mapping from edges of
+                the model to its corresponding quadratic bias.
         """
         for (u, v), bias in quadratic.items():
             idx = self._edge_to_idx.get((u, v), self._edge_to_idx.get((v, u)))

--- a/examples/boltzmann_machine.py
+++ b/examples/boltzmann_machine.py
@@ -32,7 +32,7 @@ def run(use_qpu: bool, num_reads: int, batch_size: int, n_iterations: int, fully
         fully_visible (bool): Flag indicating whether the model should be fully visible.
     """
     if use_qpu:
-        sampler = DWaveSampler(solver="Advantage2_prototype2.6")
+        sampler = DWaveSampler(solver="Advantage2_system1.3")
         zephyr_grid_size = sampler.properties['topology']['shape'][0]
         G = sampler.to_networkx_graph()
         sample_kwargs = dict(
@@ -68,6 +68,7 @@ def run(use_qpu: bool, num_reads: int, batch_size: int, n_iterations: int, fully
     if fully_visible:
         hidden_nodes = None
         n_vis = G.number_of_nodes()
+        kind = None
     else:
         # Use a four-colouring of the Zephyr graph to determine a set of conditionally-independent
         # nodes to define as hidden units.
@@ -76,6 +77,7 @@ def run(use_qpu: bool, num_reads: int, batch_size: int, n_iterations: int, fully
         hidden_nodes = [q for q, c in qubit_colour.items() if c == 0]
         n_hid = len(hidden_nodes)
         n_vis = G.number_of_nodes() - n_hid
+        kind = "sampling"
 
     # Generate fake data to fit the Boltzmann machine to
     # Make sure ``x`` is of type float
@@ -103,7 +105,7 @@ def run(use_qpu: bool, num_reads: int, batch_size: int, n_iterations: int, fully
         # Compute a quasi-objective---this quasi-objective yields the same gradient as the negative
         # log likelihood of the model
         quasi = grbm.quasi_objective(
-            x, s, kind="sampling", sampler=sampler, sample_kwargs=sample_kwargs,
+            x, s, kind=kind, sampler=sampler, sample_kwargs=sample_kwargs,
             prefactor=prefactor, linear_range=h_range, quadratic_range=j_range
         )
 

--- a/examples/boltzmann_machine.py
+++ b/examples/boltzmann_machine.py
@@ -91,7 +91,8 @@ def run(use_qpu: bool, num_reads: int, batch_size: int, n_iterations: int, fully
     # Generate a sample set from the model
     for iteration, x in enumerate(X):
         # Sample from the model
-        s = grbm.sample(sampler, prefactor, h_range, j_range, sample_params=sample_kwargs)
+        s = grbm.sample(sampler, prefactor=prefactor, linear_range=h_range,
+                        quadratic_range=j_range, sample_params=sample_kwargs)
 
         # Measure the effective inverse temperature
         measured_beta = grbm.estimate_beta(s)
@@ -103,7 +104,8 @@ def run(use_qpu: bool, num_reads: int, batch_size: int, n_iterations: int, fully
         # log likelihood of the model
         quasi = grbm.quasi_objective(
             x, s, kind="sampling", sampler=sampler, sample_kwargs=sample_kwargs,
-            prefactor=prefactor, linear_range=h_range, quadratic_range=j_range)
+            prefactor=prefactor, linear_range=h_range, quadratic_range=j_range
+        )
 
         # Backpropgate gradients
         quasi.backward()
@@ -120,8 +122,5 @@ def run(use_qpu: bool, num_reads: int, batch_size: int, n_iterations: int, fully
 
 
 if __name__ == "__main__":
-    # Run example of fitting a Boltzmann machine with a classical sampler
-    run(use_qpu=False, num_reads=100, batch_size=100, n_iterations=100, fully_visible=False)
-    run(use_qpu=False, num_reads=100, batch_size=100, n_iterations=100, fully_visible=False)
-    run(use_qpu=True, num_reads=100, batch_size=100, n_iterations=100, fully_visible=True)
-    run(use_qpu=True, num_reads=100, batch_size=100, n_iterations=100, fully_visible=False)
+    # Run example of fitting a fully-visible Boltzmann machine with a classical sampler
+    run(use_qpu=False, num_reads=100, batch_size=100, n_iterations=3, fully_visible=True)

--- a/releasenotes/notes/custom-weights-b51207c91992c8df.yaml
+++ b/releasenotes/notes/custom-weights-b51207c91992c8df.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - Support custom weight initialization and setting.
+fixes:
+  - Make ``GraphRestrictedBoltzmannMachine.quasi_objective``'s argument ``kind`` optional.

--- a/tests/test_boltzmann_machine.py
+++ b/tests/test_boltzmann_machine.py
@@ -57,6 +57,10 @@ class TestGraphRestrictedBoltzmannMachine(unittest.TestCase):
             [self.bm._idx_to_node[i] for i in range(self.bm._n_nodes)], self.bm._nodes
         )
         self.assertRaises(NotImplementedError, GRBM, [0, 1, 2], [[0, 1]], [0, 1])
+        self.bm.set_linear({"d": 999})
+        self.assertEqual(999, self.bm.linear[0])
+        self.bm.set_quadratic({("d", "b"): 999})
+        self.assertEqual(999, self.bm.quadratic[0])
 
     def test_forward(self):
         # Model for reference:
@@ -275,7 +279,7 @@ class TestGraphRestrictedBoltzmannMachine(unittest.TestCase):
         ones = torch.ones((1, 4))
         mones = -ones
         with self.subTest("Test gradients"):
-            obj = grbm.quasi_objective(ones, mones, kind="exact-disc")
+            obj = grbm.quasi_objective(ones, mones)
             obj.backward()
             t1 = grbm.sufficient_statistics(ones)
             t2 = grbm.sufficient_statistics(mones)
@@ -288,8 +292,8 @@ class TestGraphRestrictedBoltzmannMachine(unittest.TestCase):
             s1 = torch.vstack([ones, ones, ones, pmones])
             s2 = torch.vstack([ones, ones, ones, mpones])
             s3 = torch.vstack([s2, s2])
-            self.assertEqual(-1, grbm.quasi_objective(s1, s2, kind="exact-disc").item())
-            self.assertEqual(-1, grbm.quasi_objective(s1, s3, kind="exact-disc"))
+            self.assertEqual(-1, grbm.quasi_objective(s1, s2).item())
+            self.assertEqual(-1, grbm.quasi_objective(s1, s3))
 
 
 if __name__ == "__main__":

--- a/tests/test_boltzmann_machine.py
+++ b/tests/test_boltzmann_machine.py
@@ -57,10 +57,28 @@ class TestGraphRestrictedBoltzmannMachine(unittest.TestCase):
             [self.bm._idx_to_node[i] for i in range(self.bm._n_nodes)], self.bm._nodes
         )
         self.assertRaises(NotImplementedError, GRBM, [0, 1, 2], [[0, 1]], [0, 1])
-        self.bm.set_linear({"d": 999})
-        self.assertEqual(999, self.bm.linear[0])
+        # Create a triangle graph with an additional dangling vertex
+        #       a
+        #     / | \
+        #    b--c  d
+        # Note the node order is deliberately "dbac" in order to test variable orderings
+        self.nodes = list("dbac")
+        self.edges = [["a", "b"], ["a", "c"], ["a", "d"], ["b", "c"]]
+        w1 = 13337.14
+        w2 = 4812.23
+        bm = GRBM(self.nodes, self.edges, None, {"a": w1}, {("b", "c"): w2})
+        self.assertAlmostEqual(bm.linear[2].item(), w1, 2)
+        self.assertAlmostEqual(bm.quadratic[3].item(), w2, 2)
+
+    def test_quadratic(self):
         self.bm.set_quadratic({("d", "b"): 999})
         self.assertEqual(999, self.bm.quadratic[0])
+        self.bm.set_quadratic({})
+
+    def test_set_linear(self):
+        self.bm.set_linear({"d": 999})
+        self.assertEqual(999, self.bm.linear[0])
+        self.bm.set_linear({})
 
     def test_forward(self):
         # Model for reference:


### PR DESCRIPTION
1. Enable custom weight initialization and setting.
2. Fix a confusing arg combination in the quasi objective function where `kind` needs to be specified when the model is fully visible