### PR TITLE
Fix and test autograd with hidden units

### DIFF
--- a/releasenotes/notes/fix-grad-with-hidden-units-e74349975573db02.yaml
+++ b/releasenotes/notes/fix-grad-with-hidden-units-e74349975573db02.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix the (automatic) gradient computation when hidden units are present. The issue was that the
+    parameters, linear and quadratic weights, were used in the marginalization without being
+    detached from the computation graph. The fix was to detach the parameters when computing
+    effective fields.


### PR DESCRIPTION
- Fix the autograd computation when hidden units are present. The gradients were computed incorrectly because the linear and quadratic parameters were used to marginalize hidden units without detaching from the computation graph. The fix is to detach them when computing effective fields.
- Add a test to check the gradient is as expected.


Thanks @mhramani for flagging the lack of tests, which lead to discovering this bug!