### PR TITLE
Return samples in `pseudo_kl_divergence_loss`

### DIFF
--- a/releasenotes/notes/kld-requires-boltzmann-samples-67ae24105364b205.yaml
+++ b/releasenotes/notes/kld-requires-boltzmann-samples-67ae24105364b205.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    ``dwave.plugins.torch.models.losses.kl_divergence.pseudo_kl_divergence_loss``
+    no longer uses the Graph-Restricted Boltzmann Machine to generate Boltzmann
+    samples internally. Instead, the samples must be provided as an argument
+    to the function. This is a breaking change.

--- a/tests/test_dvae_winci2020.py
+++ b/tests/test_dvae_winci2020.py
@@ -129,12 +129,17 @@ class TestDiscreteVariationalAutoencoder(unittest.TestCase):
 
             discretes = discretes.reshape(discretes.shape[0], -1)
             latents = latents.reshape(latents.shape[0], -1)
+            samples = self.boltzmann_machine.sample(
+                self.sampler_sa,
+                as_tensor=True,
+                prefactor=1.0,
+                sample_params=dict(num_sweeps=10, seed=1234, num_reads=100),
+            )
             kl_loss = pseudo_kl_divergence_loss(
                 discretes,
                 latents,
+                samples,
                 self.boltzmann_machine,
-                self.sampler_sa,
-                dict(num_sweeps=10, seed=1234, num_reads=100),
             )
             loss = loss + 1e-1 * kl_loss
             optimiser.zero_grad()


### PR DESCRIPTION
When using `pseudo_kl_divergence_loss`, it would be nice to get the spinstrings sampled inside this function so that one can perform other calculations with those samples.