### PR TITLE
Fix BlockSampler validation of a graph with self edges

### DIFF
--- a/dwave/plugins/torch/samplers/block_spin_sampler.py
+++ b/dwave/plugins/torch/samplers/block_spin_sampler.py
@@ -174,6 +174,8 @@ class BlockSampler(TorchSampler):
             bool: True if the colouring is valid and False otherwise.
         """
         for u, v in self._grbm.edges:
+            if u == v:
+                continue
             if self._colouring(u) == self._colouring(v):
                 return False
         return True


### PR DESCRIPTION
Fixes #69

When `BlockSampler` is instantiated on a graph that has self edges, `_valid_colouring` incorrectly returns `False` because a node always shares a color with itself. This PR updates the validation logic to ignore self edges.