### PR TITLE
gaussian grbm initialization

### DIFF
--- a/dwave/plugins/torch/models/boltzmann_machine.py
+++ b/dwave/plugins/torch/models/boltzmann_machine.py
@@ -53,7 +53,7 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
     `Hinton's practical guide for RBM training<https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf>`_, which recommends sampling 
     weights from a Gaussian distribution with mean 0 and standard deviation 0.01 (for zero-one-valued RBMs). 
     The scaling factor of :math:`1/\sqrt(N)` ensures that the energy functional remains extensive 
-    and initializes the graph RBM in a paramagnetic regime, consistent with the ` Sherrington-Kirkpatrick model<https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.
+    and initializes the GRBM in a paramagnetic regime, consistent with the `Sherrington-Kirkpatrick model<https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.
     The biases are initialized to zero to ensure extensiveness of the energy functional and to avoid introducing any initial preference for spin configurations.
 
     Args:

--- a/dwave/plugins/torch/models/boltzmann_machine.py
+++ b/dwave/plugins/torch/models/boltzmann_machine.py
@@ -52,7 +52,7 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
     The initialization-strategy is grounded in  
     `Hinton's practical guide for RBM training<https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf>`_, which recommends sampling 
     weights from a Gaussian distribution with mean 0 and standard deviation 0.01 (for zero-one-valued RBMs). 
-    The scaling factor of 1/sqrt(N) ensures that the energy functional remains extensive 
+    The scaling factor of :math:`1/\sqrt(N)` ensures that the energy functional remains extensive 
     and initializes the graph RBM in a paramagnetic regime, consistent with the Sherrington-Kirkpatrick model 
     `<https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.
 

--- a/dwave/plugins/torch/models/boltzmann_machine.py
+++ b/dwave/plugins/torch/models/boltzmann_machine.py
@@ -53,8 +53,7 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
     `Hinton's practical guide for RBM training<https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf>`_, which recommends sampling 
     weights from a Gaussian distribution with mean 0 and standard deviation 0.01 (for zero-one-valued RBMs). 
     The scaling factor of :math:`1/\sqrt(N)` ensures that the energy functional remains extensive 
-    and initializes the graph RBM in a paramagnetic regime, consistent with the Sherrington-Kirkpatrick model 
-    `<https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.
+    and initializes the graph RBM in a paramagnetic regime, consistent with the ` Sherrington-Kirkpatrick model<https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.
 
     Args:
         nodes (Iterable[Hashable]): List of nodes.

--- a/dwave/plugins/torch/models/boltzmann_machine.py
+++ b/dwave/plugins/torch/models/boltzmann_machine.py
@@ -49,9 +49,9 @@ __all__ = ["GraphRestrictedBoltzmannMachine"]
 class GraphRestrictedBoltzmannMachine(torch.nn.Module):
     """Creates a graph-restricted Boltzmann machine.
 
-    The initialization strategy is grounded in Hinton's practical guide for RBM training 
-    `<https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf>`_, which recommends sampling 
-    weights from a Gaussian distribution with mean 0 and standard deviation 0.01. 
+    The initialization-strategy is grounded in  
+    `Hinton's practical guide for RBM training<https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf>`_, which recommends sampling 
+    weights from a Gaussian distribution with mean 0 and standard deviation 0.01 (for zero-one-valued RBMs). 
     The scaling factor of 1/sqrt(N) ensures that the energy functional remains extensive 
     and initializes the graph RBM in a paramagnetic regime, consistent with the Sherrington-Kirkpatrick model 
     `<https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.

--- a/dwave/plugins/torch/models/boltzmann_machine.py
+++ b/dwave/plugins/torch/models/boltzmann_machine.py
@@ -54,6 +54,7 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
     weights from a Gaussian distribution with mean 0 and standard deviation 0.01 (for zero-one-valued RBMs). 
     The scaling factor of :math:`1/\sqrt(N)` ensures that the energy functional remains extensive 
     and initializes the graph RBM in a paramagnetic regime, consistent with the ` Sherrington-Kirkpatrick model<https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.
+    The biases are initialized to zero to ensure extensiveness of the energy functional and to avoid introducing any initial preference for spin configurations.
 
     Args:
         nodes (Iterable[Hashable]): List of nodes.
@@ -88,7 +89,7 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
         self._idx_to_edge = {i: e for i, e in enumerate(self._edges)}
         self._edge_to_idx = {e: i for i, e in self._idx_to_edge.items()}
 
-        self._linear = torch.nn.Parameter(torch.randn(self._n_nodes)/self._n_nodes**0.5)
+        self._linear = torch.nn.Parameter(torch.zeros(self._n_nodes))
         self._quadratic = torch.nn.Parameter(torch.randn(self._n_edges)/self._n_nodes**0.5)
 
         edge_idx_i = torch.tensor([self._node_to_idx[i] for i, _ in self._edges])

--- a/dwave/plugins/torch/models/boltzmann_machine.py
+++ b/dwave/plugins/torch/models/boltzmann_machine.py
@@ -82,8 +82,8 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
         self._idx_to_edge = {i: e for i, e in enumerate(self._edges)}
         self._edge_to_idx = {e: i for i, e in self._idx_to_edge.items()}
 
-        self._linear = torch.nn.Parameter(0.05 * (2 * torch.rand(self._n_nodes) - 1))
-        self._quadratic = torch.nn.Parameter(5.0 * (2 * torch.rand(self._n_edges) - 1))
+        self._linear = torch.nn.Parameter(torch.randn(self._n_nodes)/torch.tensor(self._n_nodes, dtype=torch.float).sqrt())
+        self._quadratic = torch.nn.Parameter(torch.randn(self._n_edges)/torch.tensor(self._n_nodes, dtype=torch.float).sqrt())
 
         edge_idx_i = torch.tensor([self._node_to_idx[i] for i, _ in self._edges])
         edge_idx_j = torch.tensor([self._node_to_idx[j] for _, j in self._edges])

--- a/dwave/plugins/torch/models/boltzmann_machine.py
+++ b/dwave/plugins/torch/models/boltzmann_machine.py
@@ -49,6 +49,13 @@ __all__ = ["GraphRestrictedBoltzmannMachine"]
 class GraphRestrictedBoltzmannMachine(torch.nn.Module):
     """Creates a graph-restricted Boltzmann machine.
 
+    The initialization strategy is grounded in Hinton's practical guide for RBM training 
+    `<https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf>`_, which recommends sampling 
+    weights from a Gaussian distribution with mean 0 and standard deviation 0.01. 
+    The scaling factor of 1/sqrt(N) ensures that the energy functional remains extensive 
+    and initializes the graph RBM in a paramagnetic regime, consistent with the Sherrington-Kirkpatrick model 
+    `<https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.
+
     Args:
         nodes (Iterable[Hashable]): List of nodes.
         edges (Iterable[tuple[Hashable, Hashable]]): List of edges.

--- a/dwave/plugins/torch/models/boltzmann_machine.py
+++ b/dwave/plugins/torch/models/boltzmann_machine.py
@@ -82,8 +82,8 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
         self._idx_to_edge = {i: e for i, e in enumerate(self._edges)}
         self._edge_to_idx = {e: i for i, e in self._idx_to_edge.items()}
 
-        self._linear = torch.nn.Parameter(torch.randn(self._n_nodes)/torch.tensor(self._n_nodes, dtype=torch.float).sqrt())
-        self._quadratic = torch.nn.Parameter(torch.randn(self._n_edges)/torch.tensor(self._n_nodes, dtype=torch.float).sqrt())
+        self._linear = torch.nn.Parameter(torch.randn(self._n_nodes)/self._n_nodes**0.5)
+        self._quadratic = torch.nn.Parameter(torch.randn(self._n_edges)/self._n_nodes**0.5)
 
         edge_idx_i = torch.tensor([self._node_to_idx[i] for i, _ in self._edges])
         edge_idx_j = torch.tensor([self._node_to_idx[j] for _, j in self._edges])

--- a/dwave/plugins/torch/models/boltzmann_machine.py
+++ b/dwave/plugins/torch/models/boltzmann_machine.py
@@ -53,7 +53,7 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
     `Hinton's practical guide for RBM training<https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf>`_, which recommends sampling 
     weights from a Gaussian distribution with mean 0 and standard deviation 0.01 (for zero-one-valued RBMs). 
     The scaling factor of :math:`1/\sqrt(N)` ensures that the energy functional remains extensive 
-    and initializes the GRBM in a paramagnetic regime, consistent with the `Sherrington-Kirkpatrick model<https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.
+    and initializes the GRBM in a paramagnetic regime, consistent with the `Sherrington-Kirkpatrick model <https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.
     The biases are initialized to zero to ensure extensiveness of the energy functional and to avoid introducing any initial preference for spin configurations.
 
     Args:

--- a/dwave/plugins/torch/models/boltzmann_machine.py
+++ b/dwave/plugins/torch/models/boltzmann_machine.py
@@ -90,7 +90,7 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
         self._edge_to_idx = {e: i for i, e in self._idx_to_edge.items()}
 
         self._linear = torch.nn.Parameter(torch.zeros(self._n_nodes))
-        self._quadratic = torch.nn.Parameter(torch.randn(self._n_edges)/self._n_nodes**0.5)
+        self._quadratic = torch.nn.Parameter(torch.randn(self._n_edges) / self._n_nodes**0.5)
 
         edge_idx_i = torch.tensor([self._node_to_idx[i] for i, _ in self._edges])
         edge_idx_j = torch.tensor([self._node_to_idx[j] for _, j in self._edges])

--- a/dwave/plugins/torch/models/boltzmann_machine.py
+++ b/dwave/plugins/torch/models/boltzmann_machine.py
@@ -46,15 +46,21 @@ spread = AggregatedSamples.spread
 __all__ = ["GraphRestrictedBoltzmannMachine"]
 
 
+
 class GraphRestrictedBoltzmannMachine(torch.nn.Module):
     """Creates a graph-restricted Boltzmann machine.
 
-    The initialization-strategy is grounded in  
-    `Hinton's practical guide for RBM training<https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf>`_, which recommends sampling 
-    weights from a Gaussian distribution with mean 0 and standard deviation 0.01 (for zero-one-valued RBMs). 
-    The scaling factor of :math:`1/\sqrt(N)` ensures that the energy functional remains extensive 
-    and initializes the GRBM in a paramagnetic regime, consistent with the `Sherrington-Kirkpatrick model <https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.
-    The biases are initialized to zero to ensure extensiveness of the energy functional and to avoid introducing any initial preference for spin configurations.
+    The initialization strategy is grounded in `Hinton's practical guide for RBM training
+    <https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf>`_, which recommends sampling weights
+    from a Gaussian distribution with mean 0 and small standard deviation. The quadratic weights
+    are initialized with graph-connectivity-dependent standard deviations so the energy remains
+    extensive on sparse graphs as well as dense graphs. In particular, For edge :math:`(u, v)`,
+    we set the standard deviation of its J value as :math:`ß / (\deg(u)\deg(v))^{1/4}`, where
+    :math:`ß=2.5` is half of a representative QPU inverse sampling-temperature scale. This
+    initializes the GRBM in a paramagnetic regime, consistent with the `Sherrington-Kirkpatrick
+    model <https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.
+    The linear biases are initialized to zero to avoid introducing any initial preference for spin
+    configurations.
 
     Args:
         nodes (Iterable[Hashable]): List of nodes.
@@ -66,6 +72,13 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
         quadratic (dict[tuple[Hashable, Hashable], float]): A dictionary mapping from edges of the
             model to its corresponding quadratic bias.
     """
+    # QPU beta has been measured to be 5-8 (in inverse units of programmed J)
+    # Considering the higher temperature within this range, to sample from a beta=1
+    # Boltzmann distribution, a prefactor of 5 has to multiply the initial Hamiltonian.
+    # To keep the energy scale of the initial Hamiltonian below the effective thermal
+    # energy, we multiply the Hamiltonian weights by an even smaller prefactor so
+    # that the prepared distribution is that of a paramagnet.
+    _INIT_INVERSE_TEMP = 2.5
 
     def __init__(
         self,
@@ -89,11 +102,26 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
         self._idx_to_edge = {i: e for i, e in enumerate(self._edges)}
         self._edge_to_idx = {e: i for i, e in self._idx_to_edge.items()}
 
-        self._linear = torch.nn.Parameter(torch.zeros(self._n_nodes))
-        self._quadratic = torch.nn.Parameter(torch.randn(self._n_edges) / self._n_nodes**0.5)
+        edge_idx_i = torch.tensor([self._node_to_idx[i] for i, _ in self._edges], dtype=torch.long)
+        edge_idx_j = torch.tensor(
+            [self._node_to_idx[j] for _, j in self._edges], dtype=torch.long
+        )
 
-        edge_idx_i = torch.tensor([self._node_to_idx[i] for i, _ in self._edges])
-        edge_idx_j = torch.tensor([self._node_to_idx[j] for _, j in self._edges])
+        degrees = torch.zeros(self._n_nodes)
+        for i, j in zip(edge_idx_i, edge_idx_j):
+            degrees[i] += 1
+            degrees[j] += 1
+
+        if self._n_edges:
+            quadratic_std = self._INIT_INVERSE_TEMP / (
+                degrees[edge_idx_i] * degrees[edge_idx_j]
+            )**0.25
+            quadratic_init = torch.randn(self._n_edges) * quadratic_std
+        else:
+            quadratic_init = torch.empty(0)
+
+        self._linear = torch.nn.Parameter(torch.zeros(self._n_nodes))
+        self._quadratic = torch.nn.Parameter(quadratic_init)
 
         self.register_buffer("_edge_idx_i", edge_idx_i)
         self.register_buffer("_edge_idx_j", edge_idx_j)

--- a/releasenotes/notes/gaussian-rbm-init-28fd4d295ef86d77.yaml
+++ b/releasenotes/notes/gaussian-rbm-init-28fd4d295ef86d77.yaml
@@ -1,4 +1,16 @@
 ---
 features:
   - |
-    grbm weights and biases initialization set to Gaussian N(0,1/number of nodes)
+    Initialize ``GraphRestrictedBoltzmannMachine`` weights using Gaussian 
+    random variables with standard deviation equal to 1/sqrt(N), where N 
+    denotes the number of nodes in the gRBM.
+other:
+  - |
+    The initialization strategy is grounded in Hinton's practical guide for RBM training 
+    `<https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf>`_, which recommends sampling 
+    weights from a Gaussian distribution with mean 0 and standard deviation 0.01. 
+    The scaling factor of 1/sqrt(N) ensures that the energy functional remains extensive 
+    and initializes the graph RBM in a paramagnetic regime, consistent with the Sherrington-Kirkpatrick model 
+    `<https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.
+
+

--- a/releasenotes/notes/gaussian-rbm-init-28fd4d295ef86d77.yaml
+++ b/releasenotes/notes/gaussian-rbm-init-28fd4d295ef86d77.yaml
@@ -3,6 +3,6 @@ features:
   - |
     Initialize ``GraphRestrictedBoltzmannMachine`` weights using Gaussian 
     random variables with standard deviation equal to :math:`1/\sqrt(N)`, where N 
-    denotes the number of nodes in the GRBM. The weight-initialization strategy is grounded in `Hinton's practical guide for RBM training <https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf>`_, which recommends sampling weights from a Gaussian distribution with mean 0 and standard deviation 0.01 (for zero-one-valued RBMs). The scaling factor of :math:`1/\sqrt(N)` ensures that the energy functional remains extensive and initializes the graph RBM in a paramagnetic regime, consistent with the `Sherrington-Kirkpatrick model<https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.
+    denotes the number of nodes in the GRBM. The weight-initialization strategy is grounded in `Hinton's practical guide for RBM training <https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf>`_, which recommends sampling weights from a Gaussian distribution with mean 0 and standard deviation 0.01 (for zero-one-valued RBMs). The scaling factor of :math:`1/\sqrt(N)` ensures that the energy functional remains extensive and initializes the GRBM in a paramagnetic regime, consistent with the `Sherrington-Kirkpatrick model<https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.
 
 

--- a/releasenotes/notes/gaussian-rbm-init-28fd4d295ef86d77.yaml
+++ b/releasenotes/notes/gaussian-rbm-init-28fd4d295ef86d77.yaml
@@ -2,7 +2,7 @@
 features:
   - |
     Initialize ``GraphRestrictedBoltzmannMachine`` weights using Gaussian 
-    random variables with standard deviation equal to 1/sqrt(N), where N 
+    random variables with standard deviation equal to :math:`1/\sqrt(N)`, where N 
     denotes the number of nodes in the GRBM. The weight-initialization strategy is grounded in `Hinton's practical guide for RBM training <https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf>`_, which recommends sampling weights from a Gaussian distribution with mean 0 and standard deviation 0.01 (for zero-one-valued RBMs). The scaling factor of :math:`1/\sqrt(N)` ensures that the energy functional remains extensive and initializes the graph RBM in a paramagnetic regime, consistent with the `Sherrington-Kirkpatrick model<https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.
 
 

--- a/releasenotes/notes/gaussian-rbm-init-28fd4d295ef86d77.yaml
+++ b/releasenotes/notes/gaussian-rbm-init-28fd4d295ef86d77.yaml
@@ -3,14 +3,6 @@ features:
   - |
     Initialize ``GraphRestrictedBoltzmannMachine`` weights using Gaussian 
     random variables with standard deviation equal to 1/sqrt(N), where N 
-    denotes the number of nodes in the gRBM.
-other:
-  - |
-    The initialization strategy is grounded in Hinton's practical guide for RBM training 
-    `<https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf>`_, which recommends sampling 
-    weights from a Gaussian distribution with mean 0 and standard deviation 0.01. 
-    The scaling factor of 1/sqrt(N) ensures that the energy functional remains extensive 
-    and initializes the graph RBM in a paramagnetic regime, consistent with the Sherrington-Kirkpatrick model 
-    `<https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.
+    denotes the number of nodes in the GRBM. The weight-initialization strategy is grounded in `Hinton's practical guide for RBM training <https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf>`_, which recommends sampling weights from a Gaussian distribution with mean 0 and standard deviation 0.01 (for zero-one-valued RBMs). The scaling factor of :math:`1/\sqrt(N)` ensures that the energy functional remains extensive and initializes the graph RBM in a paramagnetic regime, consistent with the `Sherrington-Kirkpatrick model<https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.
 
 

--- a/releasenotes/notes/gaussian-rbm-init-28fd4d295ef86d77.yaml
+++ b/releasenotes/notes/gaussian-rbm-init-28fd4d295ef86d77.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    grbm weights and biases initialization set to Gaussian N(0,1/number of nodes)

--- a/releasenotes/notes/gaussian-rbm-init-28fd4d295ef86d77.yaml
+++ b/releasenotes/notes/gaussian-rbm-init-28fd4d295ef86d77.yaml
@@ -2,7 +2,7 @@
 features:
   - |
     Initialize ``GraphRestrictedBoltzmannMachine`` weights using Gaussian 
-    random variables with standard deviation equal to :math:`1/\sqrt(N)`, where N 
+    random variables with standard deviation equal to :math:`1/\sqrt(N)`, where :math:`N`
     denotes the number of nodes in the GRBM. The weight-initialization strategy is grounded in `Hinton's practical guide for RBM training <https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf>`_, which recommends sampling weights from a Gaussian distribution with mean 0 and standard deviation 0.01 (for zero-one-valued RBMs). The scaling factor of :math:`1/\sqrt(N)` ensures that the energy functional remains extensive and initializes the GRBM in a paramagnetic regime, consistent with the `Sherrington-Kirkpatrick model<https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.
 
 

--- a/releasenotes/notes/gaussian-rbm-init-28fd4d295ef86d77.yaml
+++ b/releasenotes/notes/gaussian-rbm-init-28fd4d295ef86d77.yaml
@@ -2,7 +2,13 @@
 upgrade:
   - |
     Initialize ``GraphRestrictedBoltzmannMachine`` weights using Gaussian 
-    random variables with standard deviation equal to :math:`1/\sqrt(N)`, where :math:`N`
-    denotes the number of nodes in the GRBM. The weight-initialization strategy is grounded in `Hinton's practical guide for RBM training <https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf>`_, which recommends sampling weights from a Gaussian distribution with mean 0 and standard deviation 0.01 (for zero-one-valued RBMs). The scaling factor of :math:`1/\sqrt(N)` ensures that the energy functional remains extensive and initializes the GRBM in a paramagnetic regime, consistent with the `Sherrington-Kirkpatrick model<https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.
+    random variables with standard deviation equal to :math:`1/\sqrt(N)`, 
+    where :math:`N` denotes the number of nodes in the GRBM. 
+    The weight-initialization strategy is grounded in `Hinton's practical 
+    guide for RBM training <https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf>`_, 
+    which recommends sampling weights from a Gaussian distribution with mean 0 and standard 
+    deviation 0.01 (for zero-one-valued RBMs). The scaling factor of :math:`1/\sqrt(N)` ensures 
+    that the energy functional remains extensive and initializes the GRBM in a paramagnetic regime, 
+    consistent with the `Sherrington-Kirkpatrick model<https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.
 
 

--- a/releasenotes/notes/gaussian-rbm-init-28fd4d295ef86d77.yaml
+++ b/releasenotes/notes/gaussian-rbm-init-28fd4d295ef86d77.yaml
@@ -1,5 +1,5 @@
 ---
-features:
+upgrade:
   - |
     Initialize ``GraphRestrictedBoltzmannMachine`` weights using Gaussian 
     random variables with standard deviation equal to :math:`1/\sqrt(N)`, where :math:`N`

--- a/releasenotes/notes/gaussian-rbm-init-28fd4d295ef86d77.yaml
+++ b/releasenotes/notes/gaussian-rbm-init-28fd4d295ef86d77.yaml
@@ -1,14 +1,14 @@
 ---
 upgrade:
   - |
-    Initialize ``GraphRestrictedBoltzmannMachine`` weights using Gaussian 
-    random variables with standard deviation equal to :math:`1/\sqrt(N)`, 
-    where :math:`N` denotes the number of nodes in the GRBM. 
-    The weight-initialization strategy is grounded in `Hinton's practical 
-    guide for RBM training <https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf>`_, 
-    which recommends sampling weights from a Gaussian distribution with mean 0 and standard 
-    deviation 0.01 (for zero-one-valued RBMs). The scaling factor of :math:`1/\sqrt(N)` ensures 
-    that the energy functional remains extensive and initializes the GRBM in a paramagnetic regime, 
+    Initialize ``GraphRestrictedBoltzmannMachine`` weights using Gaussian \
+    random variables with standard deviation equal to :math:`1/\sqrt(N)`, \
+    where :math:`N` denotes the number of nodes in the GRBM. \
+    The weight-initialization strategy is grounded in `Hinton's practical \
+    guide for RBM training <https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf>`_, \
+    which recommends sampling weights from a Gaussian distribution with mean 0 and standard \
+    deviation 0.01 (for zero-one-valued RBMs). The scaling factor of :math:`1/\sqrt(N)` ensures \
+    that the energy functional remains extensive and initializes the GRBM in a paramagnetic regime, \
     consistent with the `Sherrington-Kirkpatrick model<https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.
 
 

--- a/releasenotes/notes/gaussian-rbm-init-28fd4d295ef86d77.yaml
+++ b/releasenotes/notes/gaussian-rbm-init-28fd4d295ef86d77.yaml
@@ -2,13 +2,15 @@
 upgrade:
   - |
     Initialize ``GraphRestrictedBoltzmannMachine`` weights using Gaussian \
-    random variables with standard deviation equal to :math:`1/\sqrt(N)`, \
-    where :math:`N` denotes the number of nodes in the GRBM. \
+    random variables with graph-connectivity-dependent standard deviations. \
+    For an edge :math:`(u, v)`, the default standard deviation is \
+    :math:`2.5 / (\deg(u)\deg(v))^{1/4}`. \
     The weight-initialization strategy is grounded in `Hinton's practical \
-    guide for RBM training <https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf>`_, \
+    guide for RBM training \
+    <https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf>`_, \
     which recommends sampling weights from a Gaussian distribution with mean 0 and standard \
-    deviation 0.01 (for zero-one-valued RBMs). The scaling factor of :math:`1/\sqrt(N)` ensures \
-    that the energy functional remains extensive and initializes the GRBM in a paramagnetic regime, \
-    consistent with the `Sherrington-Kirkpatrick model<https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.
-
-
+    deviation 0.01 (for zero-one-valued RBMs). The connectivity scaling keeps \
+    the energy functional extensive on sparse graphs, while the temperature factor initializes \
+    the GRBM deep in a paramagnetic regime for QPU-backed sampling, \
+    consistent with the `Sherrington-Kirkpatrick model \
+    <https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.35.1792>`_.

--- a/tests/test_boltzmann_machine.py
+++ b/tests/test_boltzmann_machine.py
@@ -71,6 +71,36 @@ class TestGraphRestrictedBoltzmannMachine(unittest.TestCase):
         self.assertAlmostEqual(bm.linear[2].item(), w1, 2)
         self.assertAlmostEqual(bm.quadratic[3].item(), w2, 2)
 
+    def test_default_quadratic_initialization_uses_connectivity(self):
+        nodes = list("abcd")
+        edges = [("a", "b"), ("a", "c"), ("a", "d"), ("b", "c")]
+        degrees = torch.tensor([3.0, 2.0, 2.0, 1.0])
+        edge_idx_i = torch.tensor([0, 0, 0, 1])
+        edge_idx_j = torch.tensor([1, 2, 3, 2])
+        expected_std = 2.5 / (degrees[edge_idx_i] * degrees[edge_idx_j])**0.25
+
+        torch.manual_seed(1234)
+        expected_quadratic = torch.randn(len(edges)) * expected_std
+
+        torch.manual_seed(1234)
+        bm = GRBM(nodes, edges)
+
+        torch.testing.assert_close(bm.linear, torch.zeros(len(nodes)))
+        torch.testing.assert_close(bm.quadratic, expected_quadratic)
+
+    def test_default_quadratic_initialization_edgeless(self):
+        bm = GRBM([0, 1, 2], [])
+
+        torch.testing.assert_close(bm.linear, torch.zeros(3))
+        self.assertEqual(0, bm.quadratic.numel())
+
+    def test_custom_quadratic_overrides_default_initialization(self):
+        bm = GRBM(
+            ["a", "b", "c"], [("a", "b"), ("b", "c")], quadratic={("b", "c"): 1.25}
+        )
+
+        self.assertAlmostEqual(1.25, bm.quadratic[1].item())
+
     def test_quadratic(self):
         self.bm.set_quadratic({("d", "b"): 999})
         self.assertEqual(999, self.bm.quadratic[0])

--- a/tests/test_dvae_winci2020.py
+++ b/tests/test_dvae_winci2020.py
@@ -81,7 +81,12 @@ class TestDiscreteVariationalAutoencoder(unittest.TestCase):
         # self.decoders is independent of number of latent dims, but we also create a dict to
         # separate them
         self.decoders = {i: Decoder(latent_features, input_features) for i in latent_dims_list}
+        # self.dvaes is a dict whose keys are the numbers of latent dims and the values are the
+        # models themselves
 
+        self.dvaes = {i: DVAE(self.encoders[i], self.decoders[i]) for i in latent_dims_list}
+
+        # Now we also create a DVAE with a trainable Encoder
         def deterministic_latent_to_discrete(logits: torch.Tensor, n_samples: int) -> torch.Tensor:
             # straight-through estimator that maps positive logits to 1 and negative logits to -1
             hard = torch.sign(logits)
@@ -89,14 +94,6 @@ class TestDiscreteVariationalAutoencoder(unittest.TestCase):
             result = hard - soft.detach() + soft
             # Now we need to repeat the result n_samples times along a new dimension
             return repeat(result, "b ... -> b n ...", n=n_samples)
-        # self.dvaes is a dict whose keys are the numbers of latent dims and the values are the
-        # models themselves
-
-        self.dvaes = {i: DVAE(
-            self.encoders[i], self.decoders[i], latent_to_discrete=deterministic_latent_to_discrete
-        ) for i in latent_dims_list}
-
-        # Now we also create a DVAE with a trainable Encoder
 
         self.dvae_with_trainable_encoder = DVAE(
             encoder=torch.nn.Linear(input_features, latent_features),
@@ -250,19 +247,22 @@ class TestDiscreteVariationalAutoencoder(unittest.TestCase):
     @parameterized.expand([(i, j) for i in range(1, 3) for j in [0, 1, 5, 1000]])
     def test_forward(self, n_latent_dims, n_samples):
         """Test the forward method."""
+        torch.manual_seed(1234)  # Set seed for reproducibility of latent_to_discrete sampling
         expected_latents = self.encoders[n_latent_dims](self.data)
         expected_discretes = self.dvaes[n_latent_dims].latent_to_discrete(
             expected_latents, n_samples
         )
         expected_reconstructed_x = self.decoders[n_latent_dims](expected_discretes)
 
+        torch.manual_seed(1234)  # Set seed again to ensure that the sampling in the forward method
+        # is the same as in the expected_discretes
         latents, discretes, reconstructed_x = self.dvaes[n_latent_dims].forward(
             x=self.data, n_samples=n_samples
         )
+        torch.testing.assert_close(latents, expected_latents)
+        torch.testing.assert_close(discretes, expected_discretes)
+        torch.testing.assert_close(reconstructed_x, expected_reconstructed_x)
 
-        assert torch.equal(reconstructed_x, expected_reconstructed_x)
-        assert torch.equal(discretes, expected_discretes)
-        assert torch.equal(latents, expected_latents)
 
 
 if __name__ == "__main__":

--- a/tests/test_dvae_winci2020.py
+++ b/tests/test_dvae_winci2020.py
@@ -78,16 +78,10 @@ class TestDiscreteVariationalAutoencoder(unittest.TestCase):
         # are the models themselves
         latent_dims_list = [1, 2]
         self.encoders = {i: Encoder(i) for i in latent_dims_list}
-        # self.decoders is independent of number of latent dims, but we also create a dict to separate
-        # them
+        # self.decoders is independent of number of latent dims, but we also create a dict to
+        # separate them
         self.decoders = {i: Decoder(latent_features, input_features) for i in latent_dims_list}
 
-        # self.dvaes is a dict whose keys are the numbers of latent dims and the values are the models
-        # themselves
-
-        self.dvaes = {i: DVAE(self.encoders[i], self.decoders[i]) for i in latent_dims_list}
-
-        # Now we also create a DVAE with a trainable Encoder
         def deterministic_latent_to_discrete(logits: torch.Tensor, n_samples: int) -> torch.Tensor:
             # straight-through estimator that maps positive logits to 1 and negative logits to -1
             hard = torch.sign(logits)
@@ -95,6 +89,14 @@ class TestDiscreteVariationalAutoencoder(unittest.TestCase):
             result = hard - soft.detach() + soft
             # Now we need to repeat the result n_samples times along a new dimension
             return repeat(result, "b ... -> b n ...", n=n_samples)
+        # self.dvaes is a dict whose keys are the numbers of latent dims and the values are the
+        # models themselves
+
+        self.dvaes = {i: DVAE(
+            self.encoders[i], self.decoders[i], latent_to_discrete=deterministic_latent_to_discrete
+        ) for i in latent_dims_list}
+
+        # Now we also create a DVAE with a trainable Encoder
 
         self.dvae_with_trainable_encoder = DVAE(
             encoder=torch.nn.Linear(input_features, latent_features),


### PR DESCRIPTION
grbm weights and biases initialization set to Gaussian N(0,1/number of nodes)

Hinton guide suggests 0.01 as standard deviation. See [https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf](https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf)

Moreover, having it set to Gaussian with this dependence on the number of nodes makes the energy extensive and initializes the gRBM in a paramagnetic phase similar to that describen in the Random Energy model paper

[https://journals.aps.org/prb/abstract/10.1103/PhysRevB.24.2613](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.24.2613)

See [https://github.com/dwavesystems/dwave-pytorch-plugin/issues/48](https://github.com/dwavesystems/dwave-pytorch-plugin/issues/48)