### PR TITLE
Update parameter in README code snippet

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Each Markov chain samples at a constant unit inverse temperature.
 
 .. code-block:: python
 
-    sampler = BlockSampler(grbm=grbm, crayon=lambda v: v in {"b", "d"}, num_chains=3, schedule=[1]*10)
+    sampler = BlockSampler(grbm=grbm, colouring=lambda v: v in {"b", "d"}, num_chains=3, schedule=[1]*10)
 
 
 Create a batch of data and perform one likelihood-optimization step

--- a/dwave/plugins/torch/models/boltzmann_machine.py
+++ b/dwave/plugins/torch/models/boltzmann_machine.py
@@ -373,12 +373,12 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
                 (b1, N) where b1 denotes the batch size and N denotes the number of
                 variables in the model.
             s_model (torch.Tensor): Tensor of spins drawn from the model with shape
-                (b2, N) where b2 denotes the batch size and N denotse the number of
+                (b2, N) where b2 denotes the batch size and N denotes the number of
                 variables in the model.
             kind (Literal["sampling", "exact-disc"]): Method for computing, or approximating,
                 marginal expectations given partial observations.
                 The "sampling" method samples, conditionally, for each observation.
-                The "exact-disc" method computes exact margnials for when hidden units are
+                The "exact-disc" method computes exact marginals for when hidden units are
                 disconnected, i.e., no connections between hidden units.
             prefactor (float, optional): A scaling applied to the Hamiltonian weights (linear and
                 quadratic weights). When None, no scaling is applied. Defaults to None.

--- a/examples/boltzmann_machine.py
+++ b/examples/boltzmann_machine.py
@@ -109,7 +109,7 @@ def run(use_qpu: bool, num_reads: int, batch_size: int, n_iterations: int, fully
             prefactor=prefactor, linear_range=h_range, quadratic_range=j_range
         )
 
-        # Backpropgate gradients
+        # Backpropagate gradients
         quasi.backward()
 
         # Update model weights with a step of stochastic gradient descent


### PR DESCRIPTION
This PR updates the parameter name from `crayon` to `colouring` in the README example which was not updated after #64.

Several other typos in module files are fixed.