### PR TITLE
Allow hidden units connections in GRBM

### DIFF
--- a/dwave/plugins/torch/models/boltzmann_machine.py
+++ b/dwave/plugins/torch/models/boltzmann_machine.py
@@ -30,6 +30,7 @@ import warnings
 from typing import TYPE_CHECKING, Hashable, Iterable, Literal, Optional, Union, overload
 
 import torch
+from einops import reduce
 
 if TYPE_CHECKING:
     from dimod import Sampler, SampleSet
@@ -135,11 +136,6 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
         self._connected_hidden = any(
             a in self.hidden_nodes and b in self.hidden_nodes for a, b in self.edges
         )
-        if self._connected_hidden:
-            err_message = (
-                "Current implementation does not support intrahidden-unit connections."
-            )
-            raise NotImplementedError(err_message)
 
         visible_idx = torch.tensor(
             [self._node_to_idx[v] for v in self._nodes if v not in self.hidden_nodes],
@@ -417,7 +413,7 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
                 # the sufficient statistics, which is then passed into the quasi objective function.
                 obs = self._compute_expectation_disconnected(s_observed)
             elif kind == "sampling":
-                obs = self._approximate_expectation_sampling(
+                obs = self._conditional_hidden_sampling(
                     s_observed, sampler, prefactor, linear_range, quadratic_range, sample_kwargs
                 )
             else:
@@ -429,7 +425,7 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
                 raise ValueError(
                     f"`kind` {kind} should not be specified if the model is fully visible.")
         return (
-            self.sufficient_statistics(obs).mean(0, True)
+            reduce(self.sufficient_statistics(obs), "... n -> n", "mean")
             - self.sufficient_statistics(s_model).mean(0, True)
         ) @ self.theta
 
@@ -464,7 +460,7 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
 
         return h_eff
 
-    def _approximate_expectation_sampling(
+    def _conditional_hidden_sampling(
         self,
         obs: torch.Tensor,
         sampler: Sampler,
@@ -473,7 +469,7 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
         quadratic_range: Optional[tuple[float, float]] = None,
         sample_kwargs: Optional[dict] = None,
     ) -> torch.Tensor:
-        """Approximate expectation of hidden units via sampling.
+        """Fill hidden units via conditional sampling.
 
         This is a computationally expensive method as it requires performing sampling for every
         observation in ``obs``.
@@ -492,8 +488,9 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
             sample_kwargs (dict, optional): Sample kwargs for ``sampler``. Defaults to None.
 
         Returns:
-            torch.Tensor: A tensor of shape (b, N) where N is the total number of variables in the
-            model, i.e., number of hidden and visible units and number of visible units.
+            torch.Tensor: A tensor of shape (b, M, N) where N is the total number of variables in the
+            model, i.e., number of hidden and visible units and number of visible units and M is the
+            number of samples drawn for each observation.
         """
         # Create the BQM and remove visible units
         bqm = BinaryQuadraticModel.from_ising(
@@ -531,13 +528,13 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
             # Sample from conditional distribution
             sample_set = sampler.sample(bqm, **sample_kwargs)
             # Populate the hidden indices with the average
-            avg = torch.tensor(sample_set.record.sample).float().mean(0)
-            for idx_avg, node in enumerate(sample_set.variables):
+            hiddens = torch.tensor(sample_set.record.sample).float()  # shape (n_samples, n_hidden)
+            spins = torch.tensor(spins).unsqueeze(0).repeat(hiddens.shape[0], 1).float()
+            for idx_hiddens, node in enumerate(sample_set.variables):
                 idx = self.node_to_idx[node]
-                spins[idx] = avg[idx_avg]
+                spins[:, idx] = hiddens[:, idx_hiddens]
             res.append(spins)
-
-        return torch.tensor(res, device=obs.device)
+        return torch.stack(res).to(obs.device)
 
     def _compute_expectation_disconnected(self, obs: torch.Tensor) -> torch.Tensor:
         """Compute and return the conditional expectation of spins including observed

--- a/releasenotes/notes/allow-connected-hidden-connections-5e829224cedcd2ea.yaml
+++ b/releasenotes/notes/allow-connected-hidden-connections-5e829224cedcd2ea.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Allow hidden units to be connected during `dwave.plugins.torch.models.boltzmann_machine.GraphRestrictedBoltzmannMachine`
+    construction.

--- a/tests/test_boltzmann_machine.py
+++ b/tests/test_boltzmann_machine.py
@@ -57,7 +57,6 @@ class TestGraphRestrictedBoltzmannMachine(unittest.TestCase):
         self.assertListEqual(
             [self.bm._idx_to_node[i] for i in range(self.bm._n_nodes)], self.bm._nodes
         )
-        self.assertRaises(NotImplementedError, GRBM, [0, 1, 2], [[0, 1]], [0, 1])
         # Create a triangle graph with an additional dangling vertex
         #       a
         #     / | \
@@ -280,13 +279,13 @@ class TestGraphRestrictedBoltzmannMachine(unittest.TestCase):
         prefactor = 999
 
         fake_samples = ([[-1], [1]], ["c"])
-        expectation = grbm._approximate_expectation_sampling(
-            obs, sampler, prefactor, sample_kwargs=dict(initial_states=fake_samples)).tolist()
+        expectation = grbm._conditional_hidden_sampling(
+            obs, sampler, prefactor, sample_kwargs=dict(initial_states=fake_samples)).mean(1).tolist()
         self.assertListEqual(expectation, [[-1, 0.0, 1], [-1, 0.0, -1]])
 
         fake_samples = ([[1], [1]], ["c"])
-        expectation = grbm._approximate_expectation_sampling(
-            obs, sampler, prefactor, sample_kwargs=dict(initial_states=fake_samples)).tolist()
+        expectation = grbm._conditional_hidden_sampling(
+            obs, sampler, prefactor, sample_kwargs=dict(initial_states=fake_samples)).mean(1).tolist()
         self.assertListEqual(expectation, [[-1, 1, 1.0], [-1, 1, -1.0]])
 
     def test_sampleset_to_tensor(self):
@@ -405,6 +404,60 @@ class TestGraphRestrictedBoltzmannMachine(unittest.TestCase):
         # NOTE: this test relied on the hidden units being disconnected. This assumption gives rise
         # to linearity in expectation of sufficient statistics, i.e., average spin, then calculating
         # the sufficient statistics of the average spins.
+        torch.testing.assert_close(grad, grad_auto)
+
+    def test_quasi_objective_gradient_connected_hidden_units(self):
+        grbm = GRBM([1, 2, 3],
+                    [(1, 2), (1, 3), (2, 3)],
+                    [1, 2],
+                    {1: 0.2, 2: 0.2, 3: 0.3},
+                    {(1, 2): 0.2, (1, 3): 0.3, (2, 3): 0.6})
+        # Note : In the digram bellow linear biases are shown using  <>
+        #        quadratic biases using ()
+        #                 (0.2)
+        # Model:  v1 <0.2> ----- v2  <0.2>
+        #           \           /
+        #     (0.3)  \         / (0.6)
+        #             \       /
+        #                v3 <0.3>
+        s_observed = torch.tensor([[1.0]])
+        s_model = torch.tensor([[1.0, -1.0, 1.0]])
+
+        class FixedConditionalSampler:
+            def sample(self, bqm, **kwargs):
+                # Hidden samples conditioned on v3=1.
+                hidden_samples = [[-1, -1], [-1, 1], [1, -1]]
+                return SampleSet.from_samples(
+                    (hidden_samples, list(bqm.variables)),
+                    vartype=SPIN,
+                    energy=[0.0] * len(hidden_samples),
+                )
+
+        sampler = FixedConditionalSampler()
+        quasi = grbm.quasi_objective(
+            s_observed,
+            s_model,
+            kind="sampling",
+            prefactor=1.0,
+            sampler=sampler,
+            sample_kwargs={},
+        )
+        quasi.backward()
+
+        # Manual gradient: E[t(v, h) given v3=1] - t_model where
+        # t = (v1, v2, v3, v1v2, v1v3, v2v3).
+        t_cond_samples = torch.tensor(
+            [
+                [-1.0, -1.0, 1.0, 1.0, -1.0, -1.0],
+                [-1.0, 1.0, 1.0, -1.0, -1.0, 1.0],
+                [1.0, -1.0, 1.0, -1.0, 1.0, -1.0],
+            ]
+        )
+        t_cond = t_cond_samples.mean(0)
+        t_model = torch.tensor([1.0, -1.0, 1.0, -1.0, 1.0, -1.0])
+        grad = t_cond - t_model
+
+        grad_auto = torch.cat([grbm.linear.grad, grbm.quadratic.grad])
         torch.testing.assert_close(grad, grad_auto)
 
 


### PR DESCRIPTION
Somehow, intrahidden connections were disallowed, even though all math allows handling connected hidden units. This PR gets rid of the blocker and adds a test for the quasi objective gradient computation in the case of a GRBM with hidden-hidden connections.