### PR TITLE
Add quantum-assisted neural network features

### DIFF
--- a/dwave/plugins/torch/nn/modules/ising/__init__.py
+++ b/dwave/plugins/torch/nn/modules/ising/__init__.py
@@ -1,0 +1,2 @@
+from dwave.plugins.torch.nn.modules.ising.ising import *
+from dwave.plugins.torch.nn.modules.ising.spin_statistic import *

--- a/dwave/plugins/torch/nn/modules/ising/ising.py
+++ b/dwave/plugins/torch/nn/modules/ising/ising.py
@@ -1,0 +1,436 @@
+# Copyright 2026 D-Wave
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# The use of the Ising layer implementations below with a quantum computing system is
+# protected by the intellectual property rights of D-Wave Quantum Inc. and its affiliates.
+#
+# The use of the Ising layer implementations below with D-Wave's quantum computing
+# system will require access to D-Wave’s LeapTM quantum cloud service and
+# will be governed by the Leap Cloud Subscription Agreement available at:
+# https://cloud.dwavesys.com/leap/legal/cloud_subscription_agreement/
+
+from __future__ import annotations
+
+from collections.abc import Hashable, Iterable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import dimod
+    from dwave.plugins.torch.nn.modules.ising.spin_statistic import SpinStatistic
+
+import torch
+from dimod import BinaryQuadraticModel
+from torch import nn
+
+from dwave.plugins.torch.nn.modules.ising.spin_statistic import IdentityStatistic
+from dwave.plugins.torch.utils import sampleset_to_tensor
+from dwave.system.temperatures import maximum_pseudolikelihood_temperature as mple
+
+__all__ = ["Ising", "IsingExpectation"]
+
+
+class IsingExpectation(torch.autograd.Function):
+    """Computes the sample average statistic of the Ising model.
+
+    This is a helper function to facilitate backpropagation through an Ising layer. Details of the
+    Ising layer are in :class:`.Ising`.
+
+    The gradient of the expected output statistic (``statistic`` or :math:`g` mapping from
+    :math:`\{\pm 1\} ^N` to real numbers), is the negative covariance between the sufficient statistic
+    and :math:`g`. See
+    `Graphical Models, Exponential Families, and Variational Inference <https://people.eecs.berkeley.edu/~jordan/papers/wainwright-jordan-fnt.pdf>`_
+    for a more rigorous treatment.
+
+    .. math::
+
+        \nabla_\theta \mathbb{E} \left[ g(S)\right]  & = \sum_{s\in\{\pm 1\}^d} \nabla_\theta g(s) \frac{\exp \Big \{ -\langle T(s), \theta \rangle \Big \}}{Z(\theta)}
+
+         & = \sum_{s\in\{\pm 1\}^d} \frac{g(s)}{Z(\theta)^2} \Bigg [ -T(s)\exp \Big \{ -\langle T(s), \theta \rangle  \Big\} Z(\theta) + \exp \Big \{ -\langle T(s), \theta\rangle  \Big\} \mathbb{E}\left[ T(S) \right]Z(\theta) \Bigg]
+
+         & = \sum_{s\in\{\pm 1\}^d} \frac{g(s)}{Z(\theta)} \Bigg[ -T(s)\exp \Big \{ -\langle T(s),\theta\rangle  \Big\} + \exp \Big \{ -\langle T(s), \theta\rangle  \Big\} \mathbb{E}\left[ T(S) \right]\Bigg]
+
+         & = -\mathbb{E}\left[g(S)T(S)\right] + \mathbb{E}\left[g(S)\right] \mathbb{E}\left[ T(S) \right]
+
+         & = -\text{Covariance}\left[g(S), T(S)\right].
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        spins: torch.Tensor,
+        interactions: torch.Tensor,
+        stats_out: torch.Tensor,
+        linear: torch.Tensor,
+        quadratic: torch.Tensor
+    ) -> torch.Tensor:
+        """Computes the sample average of ``stats_out``.
+
+        Args:
+            spins: Spins of shape (B, N, D1) where B is a batch size, N is the sample size of spin
+                vectors per observation in batch, and D1 is the number of nodes in the Ising model.
+            interactions: Spin-spin interaction terms of shape (B, N, D2) where B is a batch size,
+                N is the sample size of spin vectors per observation in batch, and D2 is the number
+                of edges in the Ising model.
+            stats_out: Output statistic of spins of (B, N, D3) where B is a batch size, N is the
+                sample size of spin vectors per observation in batch, and D3 is the dimension of
+                output statistics.
+            linear: Linear biases of the Ising model with shape (B, D1) where B is batch size and D1
+                is the number of nodes in the Ising model.
+            quadratic: Quadratic biases of the Ising model with shape (B, D2) where B is batch size
+                and D2 is the number of edges in the Ising model.
+
+        Raises:
+            ValueError: If ``stats_out.ndim`` != 3.
+
+        Returns:
+            torch.Tensor: Sample average of statistics with shape (B, D3).
+        """
+        if stats_out.ndim != 3:
+            raise ValueError(f"stats.ndim should be 3. stats.ndim is {stats_out.ndim}")
+
+        avg_stats = stats_out.mean(-2)
+        ctx.save_for_backward(stats_out, spins, interactions)
+        return avg_stats
+
+    @staticmethod
+    def backward(
+        ctx,
+        grad_dloss_dinput_i: torch.Tensor
+    ) -> tuple[None, None, None, torch.Tensor, torch.Tensor]:
+        """Backpropagation of gradients approximated via sample covariance.
+
+        Args:
+            grad_dloss_dinput_i: Gradients of the loss with respect to inputs y with
+                shape (B, D3) where B is batch size and D3 is dimension of output statistic.
+
+        Returns:
+            tuple[None, None, None, torch.Tensor, torch.Tensor]: Gradients with respect to the
+            linear and quadratic weights with shapes (B, D1) and (B, D2) respectively where B is
+            batch size, D1 is number of nodes in model, and D2 is number of edges in model.
+        """
+        stats, spins, interactions = ctx.saved_tensors
+        # grad_dloss_dyi = dloss / dyi
+        # jacobian = -covariance = dyi / dthetaj, each row i corresponds to grad_thetaj <y(s)>_i
+        stats_centred = stats - stats.mean(1, True)
+        spins_centred = spins - spins.mean(1, True)
+        intxn_centred = interactions - interactions.mean(1, True)
+        sample_size = stats.shape[-2]
+        dl_dlin = -torch.einsum("bmy, bmx, by -> bx",
+                                stats_centred,
+                                spins_centred,
+                                grad_dloss_dinput_i) / (sample_size - 1)
+        dl_dqdr = -torch.einsum("bmy, bmx, by -> bx",
+                                stats_centred,
+                                intxn_centred,
+                                grad_dloss_dinput_i) / (sample_size - 1)
+        return None, None, None, dl_dlin, dl_dqdr
+
+
+class Ising(nn.Module):
+    """An Ising layer in which inputs are interpreted as Hamiltonian parameters and outputs are
+    expected statistics of the system.
+
+    An Ising model is defined by a graph :math:`G = (V, E)` or, equivalently, a set of nodes and
+    edges. In implementation, the model is defined by an ordered list of nodes and edges.
+    Inputs ``x`` and ``y`` are interpreted as the linear and quadratic biases associated with
+    :math:`V` and :math:`E` respectively in the given order. The output of the model is the expected
+    output statistic (``statistic`` or :math:`g` below). That is,
+
+    .. math::
+
+        f(x, y) = \sum_{s\in\{\pm 1\}^d} g(s) \frac{\exp \Big \{ -\langle T(s), (x, y) \rangle \Big \}}{Z(x, y)}.
+
+    where
+
+    .. math::
+
+        Z(x, y) = \sum_{s\in\{\pm 1\}^d} \exp \Big \{ -\langle T(s), (x, y) \rangle \Big \}
+
+    is the partition function.
+
+    Model outputs are, in theory, deterministic. In practice, in this implementation, model outputs
+    are stochastic due to its computational intractability and thus the need to employ a Monte Carlo
+    approximation.
+
+    Inputs ``x`` and ``y`` should have shape ``(B, |V|)`` and ``(B, |E|)`` respectively where
+    ``B`` indicates a batch size. Outputs have shape ``(B, D)`` where ``D`` is the output dimension
+    of ``statistic``.
+
+    In practice, when sampling using a quantum annealer, samples are not guaranteed to be
+    Boltzmann---which is an assumption this implementation leans on. Furthermore, a quantum annealer
+    samples at an effective inverse temperature (beta) that is not guaranteed to be 1. This poses a
+    problem when the Ising module is used in conjunction with other modules, where---if beta is not
+    accounted for---gradient estimates will be off by a factor equal to beta. In other words, the
+    effective learning rate of this layer will differ from other parameters by a factor of beta.
+    To account for beta, use the method ``set_beta``. To estimate beta, use the method
+    ``estimate_betas``. See
+    `Global Warming: Temperature Estimation in Annealers <https://doi.org/10.3389/fict.2016.00023>`_.
+    for more on estimating beta.
+
+    The gradient of the expected output statistic (``statistic`` or :math:`g` mapping from
+    :math:`\{\pm 1\} ^N` to real numbers), is the negative covariance between the sufficient statistic
+    and :math:`g`. See
+    `Graphical Models, Exponential Families, and Variational Inference <https://people.eecs.berkeley.edu/~jordan/papers/wainwright-jordan-fnt.pdf>`_
+    for a more rigorous treatment.
+
+    .. math::
+
+        \nabla_\theta \mathbb{E} \left[ g(S)\right]  & = \sum_{s\in\{\pm 1\}^d} \nabla_\theta g(s) \frac{\exp \Big \{ -\langle T(s), \theta \rangle \Big \}}{Z(\theta)}
+
+         & = \sum_{s\in\{\pm 1\}^d} \frac{g(s)}{Z(\theta)^2} \Bigg [ -T(s)\exp \Big \{ -\langle T(s), \theta \rangle  \Big\} Z(\theta) + \exp \Big \{ -\langle T(s), \theta\rangle  \Big\} \mathbb{E}\left[ T(S) \right]Z(\theta) \Bigg]
+
+         & = \sum_{s\in\{\pm 1\}^d} \frac{g(s)}{Z(\theta)} \Bigg[ -T(s)\exp \Big \{ -\langle T(s),\theta\rangle  \Big\} + \exp \Big \{ -\langle T(s), \theta\rangle  \Big\} \mathbb{E}\left[ T(S) \right]\Bigg]
+
+         & = -\mathbb{E}\left[g(S)T(S)\right] + \mathbb{E}\left[g(S)\right] \mathbb{E}\left[ T(S) \right]
+
+         & = -\text{Covariance}\left[g(S), T(S)\right].
+
+    Args:
+        nodes: Nodes of the model.
+        edges: Edges of the model.
+        sampler: The sampler used to sample from the model.
+        sample_params: Keyword arguments used in the ``sampler.sample`` method.
+        beta: Effective inverse temperature of the sampler.
+        statistic: Function mapping spins to statistics. If None, the statistic corresponds
+            to the input nodes and input edges. Defaults to None.
+    """
+
+    def __init__(
+        self,
+        nodes: Iterable[Hashable],
+        edges: Iterable[tuple[Hashable, Hashable]],
+        sampler: dimod.Sampler,
+        sample_params: dict,
+        beta: float,
+        statistic: SpinStatistic | None = None,
+    ) -> None:
+        super().__init__()
+        if beta <= 0:
+            raise ValueError(f"Effective inverse temperature beta must be positive. Got {beta}.")
+
+        self._nodes = list(nodes)
+        self._edges = list(edges)
+
+        self._num_nodes = len(self.nodes)
+        self._num_edges = len(self.edges)
+
+        self._sampler = sampler
+        self._sample_params = sample_params.copy()
+        self._beta = nn.Parameter(torch.tensor(beta, dtype=torch.float32), False)
+
+        # Some indexing
+        self.register_buffer(
+            "_node_idx_of_edges_1",
+            torch.tensor([self.nodes.index(u) for u, _ in self.edges], dtype=int)
+        )
+        self.register_buffer(
+            "_node_idx_of_edges_2",
+            torch.tensor([self.nodes.index(v) for _, v in self.edges], dtype=int)
+        )
+
+        # Default to identity
+        if statistic is None:
+            statistic = IdentityStatistic(self.num_nodes)
+        self.statistic = statistic
+        self.dim_out = statistic.dim_out
+
+        # Helper function for autograd
+        self.ising_aggregation = IsingExpectation.apply
+
+    def set_sampler(self, sampler: dimod.Sampler) -> None:
+        """Set the sampler to ``sampler``.
+
+        Args:
+            sampler: The sampler used to sample from the model.
+        """
+        self._sampler = sampler
+
+    @property
+    def sampler(self) -> dimod.Sampler:
+        """Sampler used to sample from the model."""
+        return self._sampler
+
+    def set_sample_params(self, sample_params: dict) -> None:
+        """Set sampling parameters.
+
+        Args:
+            sample_params: Keyword arguments used in the ``sampler.sample`` method.
+        """
+        self._sample_params = sample_params.copy()
+
+    @property
+    def sample_params(self) -> dict:
+        """Sampling parameters used to sample from the model."""
+        return self._sample_params
+
+    @property
+    def nodes(self) -> list[Hashable]:
+        """Edges of the model."""
+        return self._nodes
+
+    @property
+    def edges(self) -> list[Hashable, Hashable]:
+        """Nodes of the model."""
+        return self._edges
+
+    @property
+    def num_nodes(self) -> int:
+        """Number of nodes in the model."""
+        return self._num_nodes
+
+    @property
+    def num_edges(self) -> int:
+        """Number of edges in the model."""
+        return self._num_edges
+
+    @property
+    def beta(self) -> nn.Parameter[torch.FloatTensor]:
+        """The effective inverse temperature of the sampler."""
+        return self._beta
+
+    def set_beta(self, beta: float) -> None:
+        """Set the effective inverse temperature of the sampler.
+
+        Args:
+            beta: The effective inverse temperature of the sampler.
+        """
+        if beta <= 0:
+            raise ValueError(f"Effective inverse temperature beta must be positive. Got {beta}.")
+        self._beta.data = torch.tensor(beta, dtype=self._beta.dtype)
+
+    @property
+    def node_idx_of_edges_1(self) -> torch.Tensor:
+        """Node indices of first endpoint of edges."""
+        return self._node_idx_of_edges_1
+
+    @property
+    def node_idx_of_edges_2(self) -> torch.Tensor:
+        """Node indices of second endpoint of edges."""
+        return self._node_idx_of_edges_2
+
+    def _interactions(self, x: torch.Tensor) -> torch.Tensor:
+        """Interaction terms of the Ising model.
+
+        Args:
+            x: Spins of shape (..., D).
+
+        Returns:
+            Interaction terms ``x[..., self.edge_idx_u] * x[..., self.edge_idx_v]``
+        """
+        return x[..., self.node_idx_of_edges_1] * x[..., self.node_idx_of_edges_2]
+
+    def _sample(
+        self,
+        linear_biases: torch.Tensor,
+        quadratic_biases: torch.Tensor
+    ) -> list[dimod.SampleSet]:
+        """Sample from a batch of models defined by ``linear/self.beta`` and ``quadratic/self.beta`` biases.
+
+        .. note:: Linear and quadratic biases are scaled by ``1/self.beta`` prior to sampling, thus extra
+        caution should be taken when estimating beta.
+
+        Args:
+            linear_biases: Linear biases of shape (B, D1) where B is batch size and D1 is the number
+                of nodes in the model.
+            quadratic_biases: Quadratic biases of shape (B, D2) where B is batch size and D2 is the
+                number of edges in the model.
+
+        Returns:
+            A corresponding list of B sample sets.
+        """
+        sample_sets = []
+        for linear, quadratic in zip(linear_biases / self.beta, quadratic_biases / self.beta):
+            sample_sets.append(self._sampler.sample_ising(
+                dict(zip(self.nodes, linear.tolist())),
+                dict(zip(self.edges, quadratic.tolist())),
+                **self._sample_params
+            ))
+        return sample_sets
+
+    def _to_tensor(
+        self,
+        sample_sets: Iterable[dimod.SampleSet],
+        device: torch.device | None = None
+    ) -> torch.Tensor:
+        """Converts a list of sample sets to a tensor.
+
+        Args:
+            sample_sets: A list of sample sets.
+            device: The device of the constructed tensor. If None, then the
+                resulting tensor is constructed on self.beta's device. Defaults to None.
+
+        Returns:
+            A tensor of shape (B, ``len(sample_sets)``, D1) where B is batch size and D1 is the
+            number of nodes in the model.
+        """
+        if device is None:
+            device = self.beta.device
+        spins = torch.stack([sampleset_to_tensor(self.nodes, ss, device) for ss in sample_sets])
+        return spins
+
+    def forward(self, linear: torch.Tensor, quadratic: torch.Tensor) -> torch.Tensor:
+        """Approximate the expected output statistics of the Ising model.
+
+        Args:
+            linear: Input data with shape (B, D1) where D1 is the number of nodes in the model.
+            linear: Input data with shape (B, D2) where D2 is the number of edges in the model.
+
+        Raises:
+            ValueError: If ``x.ndim != 2``.
+
+        Returns:
+            Sample-approximation of expected output statistics with shape (B, D3) where D3 is the
+            output dimension of the output statistic (the ``statistic`` parameter in the constructor).
+        """
+        if linear.ndim != 2:
+            raise ValueError(f"linear.ndim should be exactly 2. linear.ndim is {linear.ndim}")
+
+        if quadratic.ndim != 2:
+            raise ValueError(
+                f"quadratic.ndim should be exactly 2. quadratic.ndim is {quadratic.ndim}"
+            )
+
+        sample_sets = self._sample(linear, quadratic)
+
+        spins = self._to_tensor(sample_sets, linear.device)
+        interactions = self._interactions(spins)
+        stats_out = self.statistic(spins)
+
+        return self.ising_aggregation(spins, interactions, stats_out, linear, quadratic)
+
+    def estimate_betas(self, linear_biases, quadratic_biases) -> list[float]:
+        """Estimate the maximum pseudolikelihood temperature using
+        ``dwave.system.temperatures.maximum_pseudolikelihood_temperature``.
+
+        See
+        `Global Warming: Temperature Estimation in Annealers <https://doi.org/10.3389/fict.2016.00023>`_.
+        for more on estimating beta.
+
+        Args:
+            linear_biases: Linear biases of shape (B, D1) where B is batch size and D1 is the number
+                of nodes in the model.
+            quadratic_biases: Quadratic biases of shape (B, D2) where B is batch size and D2 is the
+                number of edges in the model.
+
+        Returns:
+            Tensor of length B estimates of inverse temperature of the model where B is batch size.
+        """
+        bqms = [BinaryQuadraticModel.from_ising(
+                dict(zip(self.nodes, linear.tolist())),
+                dict(zip(self.edges, quadratic.tolist())))
+                # NOTE: Notice `self.beta` is not used to scale when sampling, c.f., `_sample`.
+                for linear, quadratic in zip(linear_biases, quadratic_biases)]
+        sample_sets = [self._sampler.sample(bqm, **self._sample_params) for bqm in bqms]
+        betas = torch.tensor([1 / float(mple(bqm, ss)[0]) for bqm, ss in zip(bqms, sample_sets)])
+        return betas

--- a/dwave/plugins/torch/nn/modules/ising/spin_statistic.py
+++ b/dwave/plugins/torch/nn/modules/ising/spin_statistic.py
@@ -1,0 +1,132 @@
+# Copyright 2026 D-Wave
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import abc
+from collections.abc import Iterable
+
+import torch
+
+__all__ = ["SpinStatistic", "IdentityStatistic", "IsingStatistic"]
+
+
+class SpinStatistic(abc.ABC):
+    """Untrainable spin statistics for Ising output statistics.
+
+    .. caution:: These transformations should not contain any trainable parameters. While possible,
+    current implementation does not accumulate gradients for parameters used in such functions.
+
+    Args:
+        dim_out: The output dimension of the statistic.
+    """
+
+    def __init__(self, dim_out: int) -> None:
+        self._dim_out = dim_out
+
+    @property
+    def dim_out(self) -> int:
+        """Output dimension of statistic."""
+        return self._dim_out
+
+    @abc.abstractmethod
+    def _transform(self, x: torch.Tensor) -> torch.Tensor:
+        """The main function that will be invoked by ``__call__``.
+
+        Args:
+            x (torch.Tensor): Input spins of shape (B, N, D) where B is batch size, N is sample size,
+                and D is the number of spins.
+
+        Returns:
+            torch.Tensor: Output statistic applied to the third dimension of ``x``.
+        """
+
+    def __call__(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Applies the defined transformation.
+
+        Args:
+            x: Input spins of shape (B, N, D) where B is batch size, N is sample size, and D is the
+                number of spins.
+
+        Raises:
+            ValueError: If input does not have 3 dimensions.
+            ValueError: If output does not have 3 dimensions.
+            ValueError: Output dimension does not match that of promised.
+
+        Returns:
+            torch.Tensor: Output statistic applied to the third dimension of ``x``.
+        """
+        if tensor.ndim != 3:
+            raise ValueError("Input tensor should have `ndim == 3`.")
+
+        output = self._transform(tensor)
+
+        if output.ndim != 3:
+            raise ValueError("Output tensor should have `ndim == 3`.")
+
+        if output.shape[-1] != self.dim_out:
+            raise ValueError(f"Output dimension ({output.shape[2]}) does not match that "
+                             f"promised ({self.dim_out}).")
+        return output
+
+
+class IdentityStatistic(SpinStatistic):
+    """Identity function of statistics.
+
+    Args:
+        input_dim: Dimension of inputs.
+    """
+
+    def __init__(self, dim_in: int) -> None:
+        super().__init__(dim_in)
+
+    def _transform(self, x: torch.Tensor) -> torch.Tensor:
+        """Identity function."""
+        return x
+
+
+class IsingStatistic(SpinStatistic):
+    """Sufficient statistics of Ising models; a concatenation of node values and pairwise products.
+
+    Computes the concatenation of selected node spins and element-wise
+    products of spin pairs, i.e. [x[..., indices], x[..., indices_j] * x[..., indices_i]].
+
+    Args:
+        node_indices: Indices of nodes to include directly.
+        endpoints_1: First indices for pairwise interaction terms.
+        endpoints_2: Second indices for pairwise interaction terms.
+    """
+
+    def __init__(
+        self,
+        node_indices: Iterable[int],
+        endpoints_1: Iterable[int],
+        endpoints_2: Iterable[int]
+    ) -> None:
+        self.node_indices = list(node_indices)
+        self.endpoints_1 = list(endpoints_1)
+        self.endpoints_2 = list(endpoints_2)
+
+        if len(self.endpoints_1) != len(self.endpoints_2):
+            raise ValueError(
+                "Interaction indices should be of the same length, got "
+                f"length {len(self.endpoints_1)} for i and length {len(self.endpoints_2)} for j"
+            )
+
+        dim_out = len(self.node_indices) + len(self.endpoints_1)
+        super().__init__(dim_out)
+
+    def _transform(self, x: torch.Tensor) -> torch.Tensor:
+        """``x`` and pairwise products defined by the given indices."""
+        return torch.cat([x[..., self.node_indices], x[..., self.endpoints_2] * x[..., self.endpoints_1]], -1)

--- a/dwave/plugins/torch/nn/modules/linear.py
+++ b/dwave/plugins/torch/nn/modules/linear.py
@@ -17,7 +17,33 @@ from torch import nn
 
 from dwave.plugins.torch.nn.modules.utils import store_config
 
-__all__ = ["SkipLinear", "LinearBlock"]
+__all__ = ["Affine", "SkipLinear", "LinearBlock"]
+
+
+class Affine(nn.Module):
+    """An affine transformation with no trainable parameters: ``y = scale * x + shift``.
+
+    Args:
+        scale: Multiplicative factor.
+        shift: Additive offset.
+    """
+
+    @store_config
+    def __init__(self, scale: float, shift: float) -> None:
+        super().__init__()
+        self.register_buffer("scale", torch.tensor(scale))
+        self.register_buffer("shift", torch.tensor(shift))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Computes ``self.scale * x + self.shift``.
+
+        Args:
+            x: Input tensor.
+
+        Returns:
+            Affine transformation of input.
+        """
+        return self.scale * x + self.shift
 
 
 class SkipLinear(nn.Module):

--- a/releasenotes/notes/add-affine-activation-1721f95ac5932bbc.yaml
+++ b/releasenotes/notes/add-affine-activation-1721f95ac5932bbc.yaml
@@ -1,3 +1,0 @@
----
-features:
-  - Add a static affine module. It is static in the sense that there are no trainable parameters.

--- a/releasenotes/notes/add-affine-activation-1721f95ac5932bbc.yaml
+++ b/releasenotes/notes/add-affine-activation-1721f95ac5932bbc.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Add a static affine module. It is static in the sense that there are no trainable parameters.

--- a/releasenotes/notes/add-qnn-module-d196fdc3a02f8324.yaml
+++ b/releasenotes/notes/add-qnn-module-d196fdc3a02f8324.yaml
@@ -4,3 +4,4 @@ features:
     Add an Ising layer for performing quantum annealing-based neural network computations.
     Its backpropagation is computed, or approximated, using sample covariance.
   - Add statistic base class for untrainable statistics, e.g., sufficient statistics of Ising models.
+  - Add a static affine module. It is static in the sense that there are no trainable parameters.

--- a/releasenotes/notes/add-qnn-module-d196fdc3a02f8324.yaml
+++ b/releasenotes/notes/add-qnn-module-d196fdc3a02f8324.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add an Ising layer for performing quantum annealing-based neural network computations.
+    Its backpropagation is computed, or approximated, using sample covariance.
+  - Add statistic base class for untrainable statistics, e.g., sufficient statistics of Ising models.

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,3 +2,4 @@ coverage
 codecov
 parameterized
 einops
+dwave-samplers

--- a/tests/test_ising.py
+++ b/tests/test_ising.py
@@ -1,0 +1,416 @@
+# Copyright 2026 D-Wave
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+from dimod import BQM, NullSampler, SampleSet
+
+from dwave.plugins.torch.nn.modules.ising import (IdentityStatistic, Ising, IsingExpectation,
+                                                  IsingStatistic, SpinStatistic)
+from dwave.samplers import SimulatedAnnealingSampler as Neal
+from dwave.system.temperatures import maximum_pseudolikelihood_temperature as mple
+
+
+class _ConcreteStatistic(SpinStatistic):
+    """Minimal concrete implementation for testing the ABC."""
+
+    def _transform(self, x):
+        return x[..., :self.dim_out]
+
+
+class TestStatistic(unittest.TestCase):
+    """Verify the Statistic ABC enforces its contract:
+    - inputs must be 3D (batch, samples, features)
+    - outputs must be 3D with last dim == dim_out
+    """
+
+    def test_dim_out(self):
+        # The dim_out property should reflect what was passed at construction
+        stat = _ConcreteStatistic(dim_out=3)
+        self.assertEqual(stat.dim_out, 3)
+
+    def test_rejects_2d_input(self):
+        # 2D tensors lack the sample dimension
+        stat = _ConcreteStatistic(dim_out=4)
+        x = torch.randn(2, 4)
+        with self.assertRaisesRegex(ValueError, r"Input tensor.*ndim == 3"):
+            stat(x)
+
+    def test_rejects_4d_input(self):
+        # 4D tensors have an extra spatial dim
+        stat = _ConcreteStatistic(dim_out=4)
+        x = torch.randn(2, 3, 4, 5)
+        with self.assertRaisesRegex(ValueError, r"Input tensor.*ndim == 3"):
+            stat(x)
+
+    def test_rejects_wrong_output_dim(self):
+        # If _transform returns a tensor whose last dim != dim_out, catch the bug early
+        class BadStatistic(SpinStatistic):
+            def _transform(self, x):
+                return x[..., :2]
+
+        stat = BadStatistic(dim_out=5)
+        x = torch.randn(2, 3, 4)
+        with self.assertRaisesRegex(ValueError, r"Output dimension.*does not match"):
+            stat(x)
+
+    def test_rejects_wrong_output_ndim(self):
+        # If _transform collapses a dimension (e.g. returns 2D), catch it
+        class SquashStatistic(SpinStatistic):
+            def _transform(self, x):
+                return x.mean(dim=1)  # (batch, features) — loses sample dim
+
+        stat = SquashStatistic(dim_out=4)
+        x = torch.randn(2, 3, 4)
+        with self.assertRaisesRegex(ValueError, r"Output tensor.*ndim == 3"):
+            stat(x)
+
+    def test_valid_call(self):
+        # Happy path: correct shape in, correct shape out
+        stat = _ConcreteStatistic(dim_out=3)
+        x = torch.randn(2, 4, 5)
+        result = stat(x)
+        self.assertEqual(result.shape, (2, 4, 3))
+
+
+class TestIdentityStatistic(unittest.TestCase):
+    """Verify IdentityStatistic passes input through unchanged."""
+
+    def test_dim_out_matches_dim_in(self):
+        stat = IdentityStatistic(dim_in=5)
+        self.assertEqual(stat.dim_out, 5)
+
+    def test_output_equals_input(self):
+        stat = IdentityStatistic(dim_in=4)
+        x = torch.randn(2, 3, 4)
+        result = stat(x)
+        torch.testing.assert_close(result, x)
+
+    def test_output_shape(self):
+        stat = IdentityStatistic(dim_in=7)
+        x = torch.randn(5, 10, 7)
+        result = stat(x)
+        self.assertEqual(result.shape, (5, 10, 7))
+
+
+class TestIsingStatistic(unittest.TestCase):
+    """Verify Ising correctly computes [x[indices], x[indices_j]*x[indices_i]]
+    under various edge cases encountered in practice."""
+
+    def test_transform(self):
+        # Core behaviour: picks nodes and computes pairwise products
+        stat = IsingStatistic(
+            node_indices=[0, 2],
+            endpoints_1=[1],
+            endpoints_2=[3],
+        )
+        # shape (batch=1, samples=2, nodes=4)
+        x = torch.tensor([[[1.0, -1.0, 1.0, -1.0],
+                           [1.0,  1.0, -1.0, 1.0]]])
+        result = stat(x)
+        # expected: [x[...,0], x[...,2], x[...,3]*x[...,1]]
+        expected = torch.tensor([[[1.0, 1.0, (-1.0)*(-1.0)],
+                                  [1.0, -1.0, 1.0*1.0]]])
+        torch.testing.assert_close(result, expected)
+
+    def test_output_shape(self):
+        # Verify shape is (batch, samples, dim_out) for arbitrary input sizes
+        stat = IsingStatistic(
+            node_indices=[0, 1],
+            endpoints_1=[0, 2],
+            endpoints_2=[1, 3],
+        )
+        x = torch.randn(3, 5, 7)
+        result = stat(x)
+        self.assertEqual(result.shape, (3, 5, 4))
+
+    def test_no_interactions(self):
+        # Edge case: only node indices, no interaction terms
+        # (e.g. an Ising model with no input_edges)
+        stat = IsingStatistic(node_indices=[0, 3], endpoints_1=[], endpoints_2=[])
+        x = torch.tensor([[[1.0, 2.0, 3.0, 4.0]],
+                          [[0.1, 2.0, 3.0, 5.0]]])
+        result = stat(x)
+        torch.testing.assert_close(result, torch.tensor([[[1.0, 4.0]], [[0.1, 5.0]]]))
+
+    def test_no_nodes(self):
+        # Edge case: only interaction terms, no direct node indices
+        stat = IsingStatistic(node_indices=[], endpoints_1=[0], endpoints_2=[1])
+        x = torch.tensor([[[3.0, -2.0]]])
+        result = stat(x)
+        torch.testing.assert_close(result, torch.tensor([[[-6.0]]]))
+
+    def test_bad_edge_indices(self):
+        # Edge indices have different length
+        with self.assertRaisesRegex(ValueError, "Interaction indices should be of the same length, got"):
+            IsingStatistic(node_indices=[], endpoints_1=[0], endpoints_2=[1, 2])
+
+    def test_tensor_indices(self):
+        # Ising internally passes nn.Parameter tensors as indices;
+        # verify IsingStatistic handles them the same as lists
+        stat = IsingStatistic(
+            node_indices=torch.tensor([1]),
+            endpoints_1=torch.tensor([0]),
+            endpoints_2=torch.tensor([2]),
+        )
+        x = torch.nn.Parameter(torch.tensor([[[2.0, 3.0, 4.0]]]))
+        result = stat(x)
+        torch.testing.assert_close(result, torch.tensor([[[3.0, 8.0]]]))
+
+
+class TestIsingExpectation(unittest.TestCase):
+
+    def test_forward_backward(self):
+        """Test forward and backward evaluations are as expected."""
+        spins = torch.tensor([[[-1, -1, -1],
+                               [-1,  1,  1],
+                               [1,  1,  1]],
+                              [[1, -1,  1],
+                               [-1, -1,  1],
+                               [-1, -1,  1]]]).float()
+        # Interaction terms are col0*col1, col1*col2
+        interactions = spins[..., [0, 1]] * spins[..., [1, 2]]
+        sufficient_stats = torch.cat([spins, interactions], dim=-1)
+
+        # Statistic is col0 + col1, col1*col2
+        output_stats = torch.cat([spins[..., [0]] + spins[..., [1]],
+                                  spins[..., [1]] * spins[..., [2]]],
+                                 dim=-1)
+
+        linear = torch.tensor([-0.1, -0.2, -0.3], requires_grad=True)
+        quadratic = torch.tensor([0.0, 1.0], requires_grad=True)
+
+        y = IsingExpectation.apply(spins, interactions, output_stats, linear, quadratic)
+
+        with self.subTest("Ising aggregation layer produced unexpected output values"):
+            with torch.no_grad():
+                torch.testing.assert_close(y, output_stats.mean(1))
+
+        # Gradient amounts to summing over gradients per obs
+        loss = (y**2).sum()
+        loss.backward()
+
+        with torch.no_grad():
+            # Manually compute the gradients
+            dloss_dy = 2*y
+            dy_dhJ = -torch.stack([torch.cat([o, i], -1).mT.cov()[:2, 2:]
+                                   for i, o in zip(sufficient_stats, output_stats)])
+            # hJ = torch.cat([linear, quadratic]).repeat(2, 1)
+            dloss_dhJ = torch.einsum("bi, bij -> bj", dloss_dy, dy_dhJ).sum(0)
+
+        with self.subTest("Linear gradients should match"):
+            torch.testing.assert_close(dloss_dhJ[:3], linear.grad)
+
+        with self.subTest("Quadratic gradients should match"):
+            torch.testing.assert_close(dloss_dhJ[3:], quadratic.grad)
+
+
+class TestIsing(unittest.TestCase):
+
+    def test_has_properties(self):
+        ising = Ising(
+            nodes="abc",
+            edges=[("a", "b"), ("a", "c"), ("b", "c")],
+            beta=1.0,
+            sampler=NullSampler(),
+            statistic=IsingStatistic([1], [0, 1], [1, 2]),
+            sample_params=dict(a=1),
+        )
+        self.assertEqual(1.0, ising.beta)
+        self.assertListEqual(["a", "b", "c"], ising.nodes)
+        self.assertListEqual([("a", "b"), ("a", "c"), ("b", "c")], ising.edges)
+        self.assertEqual(NullSampler, ising.sampler.__class__)
+        self.assertDictEqual(dict(a=1), ising.sample_params)
+
+    def test_setters(self):
+        ising = Ising(
+            nodes="abc",
+            edges=[("a", "b"), ("a", "c"), ("b", "c")],
+            beta=1.0,
+            sampler=NullSampler(),
+            statistic=IsingStatistic([1], [0, 1], [1, 2]),
+            sample_params=dict(a=1),
+        )
+
+        with self.subTest("Set beta"):
+            ising.set_beta(342.0)
+            self.assertEqual(342.0, ising.beta)
+
+        with self.subTest("Set sampling parameters"):
+            ising.set_sample_params(dict(b=2))
+            self.assertDictEqual(dict(b=2), ising.sample_params)
+
+        with self.subTest("Set sampler"):
+            ising.set_sampler(Neal())
+            self.assertEqual(Neal, ising.sampler.__class__)
+
+    def test_correct_node_indices_of_edges(self):
+        ising = Ising(
+            nodes="abc",
+            edges=[("a", "b"), ("a", "c"), ("b", "c")],
+            beta=1.0,
+            sampler=NullSampler(),
+            statistic=IsingStatistic([1], [0, 1], [1, 2]),
+            sample_params=dict(a=1),
+        )
+        self.assertListEqual([0, 0, 1], ising.node_idx_of_edges_1.tolist())
+        self.assertListEqual([1, 2, 2], ising.node_idx_of_edges_2.tolist())
+
+    def test_sampling_with_beta(self):
+        sampler = Neal()
+        bs = 10
+        with self.subTest("Spins should be pinned"):
+            sample_params = dict(num_sweeps=1, num_reads=10000, beta_range=[1, 1])
+            model = Ising("abc", [("a", "b"), ("a", "c")],
+                          sampler, sample_params, 1e-20)
+            linear = torch.ones((bs, 3))*1e-6
+            quadratic = torch.zeros((bs, 2))
+            y = model(linear, quadratic)
+            torch.testing.assert_close(y.mean(0), -torch.ones(3))
+
+        with self.subTest("Average should be 0"):
+            sample_params = dict(num_sweeps=2, num_reads=100000, beta_range=[1, 1])
+            model = Ising("abc", [("a", "b"), ("a", "c")],
+                          sampler, sample_params, 1e30)
+            linear = torch.ones((bs, 3))
+            quadratic = torch.zeros((bs, 2))
+            y = model(linear, quadratic)
+            torch.testing.assert_close(y.mean(0), torch.zeros(3), rtol=0.001, atol=0.01)
+
+    def test_beta(self):
+        sampler = NullSampler()
+        with self.subTest("Invalid beta at initialization"):
+            with self.assertRaisesRegex(ValueError, "Effective inverse temperature beta must be positive."):
+                Ising("abc", [], sampler, dict(), 0.0)
+            with self.assertRaisesRegex(ValueError, "Effective inverse temperature beta must be positive."):
+                Ising("abc", [], sampler, dict(), -0.1)
+
+        with self.subTest("Set invalid beta"):
+            ising = Ising("abc", [], sampler, dict(), 1.0)
+            with self.assertRaisesRegex(ValueError, "Effective inverse temperature beta must be positive."):
+                ising.set_beta(0.0)
+            with self.assertRaisesRegex(ValueError, "Effective inverse temperature beta must be positive."):
+                ising.set_beta(-0.1)
+
+    def test_estimate_beta(self):
+        # Here we construct a dummy sampler to output a sample of size 3. The sampler produces these
+        # two samples and returns them in a first-in-first-out manner.
+        s1 = [[-1, -1, -1],
+              [-1,  1,  1],
+              [1,  1,  1]]
+        s2 = [[1,  -1,  1],
+              [-1, -1, 1],
+              [-1, -1, 1]]
+
+        linear = torch.tensor([[0.1, 0.2, 0.4],
+                               [-0.9, -0.8, -0.6]])
+        quadratic = torch.tensor([[1.0, 9.0, 4.0],
+                                  [0.9, 8.0, -12.0]])
+
+        h0 = dict(zip("abc", linear[0].numpy()))
+        J0 = dict(zip([("a", "b"), ("a", "c"), ("b", "c")], quadratic[0].numpy()))
+        bqm0 = BQM.from_ising(h0, J0)
+
+        h1 = dict(zip("abc", linear[1].numpy()))
+        J1 = dict(zip([("a", "b"), ("a", "c"), ("b", "c")], quadratic[1].numpy()))
+        bqm1 = BQM.from_ising(h1, J1)
+
+        class FIFOSampler:
+            def __init__(self):
+                self.samples = [
+                    SampleSet.from_samples_bqm((s1, list("abc")), bqm0),
+                    SampleSet.from_samples_bqm((s2, list("abc")), bqm1)
+                ]
+
+            def sample(self, *args, **kwargs):
+                return self.samples.pop(0)
+
+        sampler = FIFOSampler()
+        sample_params = dict()
+        model = Ising("abc", [("a", "b"), ("a", "c"), ("b", "c")],
+                      sampler, sample_params, 9999.0)
+
+        estimated_betas = model.estimate_betas(linear, quadratic)
+        dimod_betas = [
+            1 / float(mple(bqm0, (s1, list("abc")))[0].item()),
+            1 / float(mple(bqm1, (s2, list("abc")))[0].item())
+        ]
+        torch.testing.assert_close(torch.tensor(dimod_betas), estimated_betas)
+
+    def test_forward_backward(self):
+
+        # Here we construct a dummy sampler to output a sample of size 3. The sampler produces these
+        # two samples and returns them in a first-in-first-out manner.
+        s1 = [[-1, -1, -1],
+              [-1,  1,  1],
+              [1,  1,  1]]
+        s2 = [[1,  -1,  1],
+              [-1, -1, 1],
+              [-1, -1, 1]]
+
+        class FIFOSampler:
+            def __init__(self):
+                self.samples = [
+                    SampleSet.from_samples((s1, list("abc")), "SPIN", [-1, 0, -2]),
+                    SampleSet.from_samples((s2, list("abc")), "SPIN", [-1, -2, 0])
+                ]
+
+            def sample_ising(self, *args, **kwargs):
+                print(len(self.samples))
+                return self.samples.pop(0)
+
+        ising = Ising(
+            nodes="abc",
+            edges=[("a", "b"), ("a", "c"), ("b", "c")],
+            beta=1.0,
+            sampler=FIFOSampler(),
+            statistic=IsingStatistic([1], [0, 1], [1, 2]),
+            sample_params=dict(),
+        )
+
+        # linear and quadratic values don't matter here because we're using a dummy sampler
+        linear = torch.zeros((2, 3), requires_grad=True)
+        quadratic = torch.zeros((2, 3), requires_grad=True)
+        with self.subTest("Ising layer produced unexpected output values"):
+            y = ising(linear, quadratic)
+            torch.testing.assert_close(y, torch.tensor([[1/3, 1/3, 1],
+                                                        [-1, 1/3, -1]]))
+
+        # Gradient amounts to summing over gradients per obs
+        (y**2).sum().backward()
+
+        # Manually compute the gradients for first observation
+        t1 = torch.tensor(s1).float()
+        stat_1 = torch.hstack([t1[..., [1]], t1[..., [0, 1]] * t1[..., [1, 2]]])
+        input_1 = torch.hstack([t1, t1[..., [0, 0, 1]] * t1[..., [1, 2, 2]]])
+        grad1 = 2*y[0]@(-torch.cat([stat_1, input_1], -1).mT.cov()[:3, 3:])
+
+        # Manually compute the gradients for second observation
+        t2 = torch.tensor(s2).float()
+        stat_2 = torch.hstack([t2[..., [1]], t2[..., [0, 1]] * t2[..., [1, 2]]])
+        input_2 = torch.hstack([t2, t2[..., [0, 0, 1]] * t2[..., [1, 2, 2]]])
+        grad2 = 2*y[1]@(-torch.cat([stat_2, input_2], -1).mT.cov()[:3, 3:])
+
+        grad = torch.vstack([grad1, grad2])
+
+        with self.subTest("Linear gradients should match"):
+            torch.testing.assert_close(grad[:, :3], linear.grad)
+
+        with self.subTest("Quadratic gradients should match"):
+            torch.testing.assert_close(grad[:, 3:], quadratic.grad)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -16,7 +16,7 @@ import unittest
 import torch
 from parameterized import parameterized
 
-from dwave.plugins.torch.nn import LinearBlock, SkipLinear, store_config
+from dwave.plugins.torch.nn import Affine, LinearBlock, SkipLinear, store_config
 from tests.helper_functions import model_probably_good
 
 
@@ -77,6 +77,49 @@ class TestUtils(unittest.TestCase):
                              dict(a=123, b=1, x=5, y="hello", module_name="InnerModel"))
         self.assertDictEqual(dict(model.config["module_2"]),
                              dict(a="second", b=1, x=4, y="lol", module_name="InnerModel"))
+
+
+class TestAffine(unittest.TestCase):
+    """Verify the Affine module correctly applies y = scale * x + shift
+    and integrates properly with PyTorch's module system (state_dict, device)."""
+
+    def test_forward(self):
+        # Basic correctness: 2*x + 3
+        affine = Affine(scale=2.0, shift=3.0)
+        x = torch.tensor([1.0, -1.0, 0.0])
+        result = affine(x)
+        torch.testing.assert_close(result, torch.tensor([5.0, 1.0, 3.0]))
+
+    def test_forward_batched(self):
+        # Ensure broadcasting works over batch dimensions
+        affine = Affine(scale=0.5, shift=-1.0)
+        x = torch.tensor([[2.0, 4.0], [0.0, -2.0]])
+        result = affine(x)
+        torch.testing.assert_close(result, torch.tensor([[0.0, 1.0], [-1.0, -2.0]]))
+
+    def test_identity(self):
+        # scale=1, shift=0 should be a no-op
+        affine = Affine(scale=1.0, shift=0.0)
+        x = torch.tensor([1.2, 4.3, 5.0, 3.1415926535, -324234.93])
+        torch.testing.assert_close(affine(x), x)
+
+    def test_zero_scale(self):
+        # scale=0 should collapse all inputs to the shift value
+        x = torch.tensor([100.0, -100.0])
+        with self.subTest("Zero-scale affine with offset should return offset"):
+            torch.testing.assert_close(Affine(scale=0.0, shift=5.0)(x), torch.tensor([5.0, 5.0]))
+        with self.subTest("Zero-scale affine with zero-offset should return 0"):
+            torch.testing.assert_close(Affine(scale=0.0, shift=0.0)(x), torch.tensor([0.0, 0.0]))
+
+    def test_state_dict(self):
+        # scale and shift are registered buffers, so they must appear in state_dict
+        # (critical for checkpointing and .to(device) to propagate correctly)
+        affine = Affine(scale=2.0, shift=3.0)
+        sd = affine.state_dict()
+        self.assertIn("scale", sd)
+        self.assertIn("shift", sd)
+        torch.testing.assert_close(sd["scale"], torch.tensor(2.0))
+        torch.testing.assert_close(sd["shift"], torch.tensor(3.0))
 
 
 class TestLinear(unittest.TestCase):


### PR DESCRIPTION
This pull request adds quantum neural network-related modules and utilities.
- The main module is the `Ising` module and its custom autograd function `IsingExpectation`.
- The `Affine` module is used to bound weights into, e.g., QPU's linear range.
- The `SpinStatistic` class is for defining untrainable spin functions with some safe-guarding around input and output shapes.

---

Disclosure: I used Claude Opus 4.6 (via GitHub Copilot) to generate documentation, type hints, refinements, and tests for `Statistic`, `IsingStatistic`, `IdentityStatistic`, and `Affine`. I stepped through all tests and functions generated by Claude to verify the implementations' validity. By "refinements", I mean I defined and implemented these classes first, then prompted Claude to improve it. I also removed and refined the generated tests and documentation, and then added some test cases that were not covered by Claude. 

---

Note: this was [reviewed internally](https://github.com/dwavesystems/dwave-pytorch-plugin-private/pull/1) prior to publishing here.