### PR TITLE
Prevent self-loops in GRBM construction

### DIFF
--- a/dwave/plugins/torch/models/boltzmann_machine.py
+++ b/dwave/plugins/torch/models/boltzmann_machine.py
@@ -89,6 +89,12 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
         edge_idx_i = torch.tensor([self._node_to_idx[i] for i, _ in self._edges])
         edge_idx_j = torch.tensor([self._node_to_idx[j] for _, j in self._edges])
 
+        if (edge_idx_i == edge_idx_j).any():
+            loop_indices = edge_idx_i[(edge_idx_i == edge_idx_j).argwhere()].tolist()
+            raise ValueError(
+                f"Self-loops are not allowed. Edge indices with self-loops: {loop_indices}"
+            )
+
         self.register_buffer("_edge_idx_i", edge_idx_i)
         self.register_buffer("_edge_idx_j", edge_idx_j)
 
@@ -311,8 +317,7 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
         warnings.warn(
             f"`{self.__class__}.sample()()` is deprecated since dwave-pytorch-plugin "
             "0.3.0 and will be removed in 0.4.0. Use Use `dwave.plugins.torch.samplers` module "
-            "for all sampling-related tasks instead."
-            , DeprecationWarning
+            "for all sampling-related tasks instead.", DeprecationWarning
         )
 
         if sample_params is None:
@@ -343,8 +348,7 @@ class GraphRestrictedBoltzmannMachine(torch.nn.Module):
         warnings.warn(
             f"`{self.__class__}.sampleset_to_tensor()` is deprecated since dwave-pytorch-plugin "
             "0.3.0 and will be removed in 0.4.0. Use Use `dwave.plugins.torch.samplers` module "
-            "for all sampling-related tasks instead."
-            , DeprecationWarning
+            "for all sampling-related tasks instead.", DeprecationWarning
         )
 
         return sampleset_to_tensor(self._nodes, sample_set, device)

--- a/releasenotes/notes/fix-selfloop-5ce763fafe8ee1c6.yaml
+++ b/releasenotes/notes/fix-selfloop-5ce763fafe8ee1c6.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    GraphRestrictedBoltzmannMachines should not be allowed to be defined with self-loops.
+    Presence of self-loops is now checked at construction time.

--- a/tests/test_boltzmann_machine.py
+++ b/tests/test_boltzmann_machine.py
@@ -70,6 +70,17 @@ class TestGraphRestrictedBoltzmannMachine(unittest.TestCase):
         self.assertAlmostEqual(bm.linear[2].item(), w1, 2)
         self.assertAlmostEqual(bm.quadratic[3].item(), w2, 2)
 
+    def test_selfloop(self):
+        # Create a triangle graph with an additional dangling vertex
+        #       a-SELF-LOOP
+        #       | \
+        #    b--c  d
+        # Note the node order is deliberately "dbac" in order to test variable orderings
+        self.nodes = list("dbac")
+        self.edges = [["a", "a"], ["a", "c"], ["a", "d"], ["b", "c"]]
+        with self.assertRaisesRegex(ValueError, "Self-loops are not allowed"):
+            GRBM(self.nodes, self.edges, None, {"a": 0}, {("b", "c"): 0})
+
     def test_quadratic(self):
         self.bm.set_quadratic({("d", "b"): 999})
         self.assertEqual(999, self.bm.quadratic[0])


### PR DESCRIPTION
This fixes #69 

> I think the fix should be at the GRBM level. Self-edges should be disallowed at construction since s 2 = 1 

https://github.com/dwavesystems/dwave-pytorch-plugin/issues/69#issuecomment-4053096316

AI disclosure: artisanal code yo